### PR TITLE
Feat/event invites notifications

### DIFF
--- a/lib/services/events_S/event_service.dart
+++ b/lib/services/events_S/event_service.dart
@@ -10,7 +10,7 @@ import '../../model/events_M/events_model.dart';
 import '../../model/game_library_M/game_details_model.dart';
 import '../../services/game_library_S/my_games_service.dart';
 
-class Events {
+class EventsService {
   Stream<List<Event>> fetchAllEvents()  async* {
     try {
       FirebaseFirestore db = FirebaseFirestore.instance;
@@ -106,6 +106,21 @@ class Events {
       
     }catch (e){
       return await storage.child('events/default_image.jpg').getDownloadURL();
+    }
+  }
+
+  Future<void> declineEventInvitation(Event event) async {
+    final DocumentReference docRef = FirebaseFirestore.instance.collection('events').doc(event.eventID);
+
+    try {
+      final currentUser = FirebaseAuth.instance.currentUser;
+      if (currentUser != null) {
+        await docRef.update({
+          'invited_users': FieldValue.arrayRemove([currentUser.uid])
+        });
+      }
+    } catch (e) {
+      throw ('Error: $e');
     }
   }
 

--- a/lib/services/events_S/event_service.dart
+++ b/lib/services/events_S/event_service.dart
@@ -57,8 +57,8 @@ class EventsService {
     for (var doc in snapshot.docs) {
       Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
       data['id'] = doc.id;
-      if (data['invited_users'] != null && data['invited_users'] is List) {
-        List<dynamic> array = data['invited_users'];
+      if (data['invited'] != null && data['invited'] is List) {
+        List<dynamic> array = data['invited'];
 
         if (array.contains(currentUser!.uid)) {
           invitedEvents.add(data);
@@ -136,7 +136,7 @@ class EventsService {
       final currentUser = FirebaseAuth.instance.currentUser;
       if (currentUser != null) {
         await docRef.update({
-          'invited_users': FieldValue.arrayRemove([currentUser.uid])
+          'invited': FieldValue.arrayRemove([currentUser.uid])
         });
       }
     } catch (e) {

--- a/lib/services/events_S/event_service.dart
+++ b/lib/services/events_S/event_service.dart
@@ -45,8 +45,28 @@ class EventsService {
       e = Event.fromMap(data, id);
     }
     return e;
+  }
 
+  Future<List<Map<String, dynamic>>> getInvitedEvents() async {
+    FirebaseFirestore db = FirebaseFirestore.instance;
+    List<Map<String, dynamic>> invitedEvents = [];
+    final currentUser = FirebaseAuth.instance.currentUser;
 
+    QuerySnapshot snapshot = await db.collection('events').get();
+
+    for (var doc in snapshot.docs) {
+      Map<String, dynamic> data = doc.data() as Map<String, dynamic>;
+      data['id'] = doc.id;
+      if (data['invited_users'] != null && data['invited_users'] is List) {
+        List<dynamic> array = data['invited_users'];
+
+        if (array.contains(currentUser!.uid)) {
+          invitedEvents.add(data);
+        }
+      }
+    }
+
+    return invitedEvents;
   }
 
   Future<void> createEvent(

--- a/lib/view/components/card/event_card.dart
+++ b/lib/view/components/card/event_card.dart
@@ -27,7 +27,7 @@ class EventCard extends State<EventCardWidget> {
   }
 
   void getEvent() async{
-    Event? updated = await Events().getEvent(e.eventID);
+    Event? updated = await EventsService().getEvent(e.eventID);
     setState(() {
       e = updated!;
     });

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -13,8 +13,8 @@ class EventInvitation extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: ExpansionTile(
+    return Expanded(
+      child: ExpansionTile(
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -1,15 +1,37 @@
-import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:gameonconnect/services/events_S/event_service.dart';
 import 'package:gameonconnect/model/events_M/events_model.dart';
-import 'package:gameonconnect/model/connection_M/user_model.dart';
+import 'package:gameonconnect/services/profile_S/profile_service.dart';
 
-class EventInvitation extends StatelessWidget {
-  final String inviter;
+class EventInvitation extends StatefulWidget {
+  final String inviterId;
   final Event event;
-  final EventsService _eventsService = EventsService();
+  String inviterName = "";
 
-  EventInvitation({super.key, required this.inviter, required this.event});
+  EventInvitation({super.key, required this.inviterId, required this.event});
+
+  @override
+  State<EventInvitation> createState() => _EventInvitationState();
+}
+
+class _EventInvitationState extends State<EventInvitation> {
+  final EventsService _eventsService = EventsService();
+  final ProfileService _profileService = ProfileService();
+
+  @override
+  void initState() {
+    super.initState();
+    _changeIdToName();
+  }
+
+  Future<void> _changeIdToName() async {
+    String? inviterName =
+        await _profileService.getProfileName(widget.inviterId);
+
+    setState(() {
+      widget.inviterName = inviterName!;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -18,41 +40,44 @@ class EventInvitation extends StatelessWidget {
         title: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              '$inviter invited you to join',
-              style: const TextStyle(
-                fontWeight: FontWeight.bold
-              )
-            ),
-            Text(
-              event.name,
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                color: Colors.green
-              )
-            )
+            Text('${widget.inviterName} invited you to join',
+                style: const TextStyle(fontWeight: FontWeight.bold)),
+            Text(widget.event.name,
+                style: const TextStyle(
+                    fontWeight: FontWeight.bold, color: Colors.green)),
           ],
         ),
-        children: <Widget> [
+        children: <Widget>[
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Description: ${widget.event.description}',
+              ),
+              Text(
+                'Date: ${widget.event.startDate}',
+              )
+            ],
+          ),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               FilledButton(
-                onPressed: () {
-                  _eventsService.joinEvent(event);
-                }, 
-                child: const Text('Accept')),
+                  onPressed: () {
+                    _eventsService.joinEvent(widget.event);
+                  },
+                  child: const Text('Accept')),
               FilledButton(
-                onPressed: () {
-                  _eventsService.declineEventInvitation(event);
-                }, 
-                child: const Text('Decline')),
+                  onPressed: () {
+                    _eventsService.declineEventInvitation(widget.event);
+                  },
+                  child: const Text('Decline')),
               FilledButton(
-                onPressed: () {
-                  _eventsService.declineEventInvitation(event);
-                  _eventsService.subscribeToEvent(event);
-                }, 
-                child: const Text('Stay notified')),
+                  onPressed: () {
+                    _eventsService.declineEventInvitation(widget.event);
+                    _eventsService.subscribeToEvent(widget.event);
+                  },
+                  child: const Text('Stay notified')),
             ],
           )
         ],

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -18,6 +18,7 @@ class EventInvitation extends StatefulWidget {
 class _EventInvitationState extends State<EventInvitation> {
   final EventsService _eventsService = EventsService();
   final ProfileService _profileService = ProfileService();
+  bool _isWidgetVisible = true;
 
   @override
   void initState() {
@@ -36,6 +37,7 @@ class _EventInvitationState extends State<EventInvitation> {
 
   @override
   Widget build(BuildContext context) {
+    if (_isWidgetVisible) {
     return Expanded(
       child: ExpansionTile(
         title: Column(
@@ -65,18 +67,28 @@ class _EventInvitationState extends State<EventInvitation> {
             children: [
               FilledButton(
                   onPressed: () {
+                    _eventsService.declineEventInvitation(widget.event);
                     _eventsService.joinEvent(widget.event);
+                    setState(() {
+                      _isWidgetVisible = false;
+                    });
                   },
                   child: const Text('Accept')),
               FilledButton(
                   onPressed: () {
                     _eventsService.declineEventInvitation(widget.event);
+                    setState(() {
+                      _isWidgetVisible = false;
+                    });
                   },
                   child: const Text('Decline')),
               FilledButton(
                   onPressed: () {
                     _eventsService.declineEventInvitation(widget.event);
                     _eventsService.subscribeToEvent(widget.event);
+                    setState(() {
+                      _isWidgetVisible = false;
+                    });
                   },
                   child: const Text('Stay notified')),
             ],
@@ -84,5 +96,8 @@ class _EventInvitationState extends State<EventInvitation> {
         ],
       ),
     );
+    } else {
+      return const SizedBox(height: 0);
+    }
   }
 }

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -5,7 +5,7 @@ import 'package:gameonconnect/model/events_M/events_model.dart';
 import 'package:gameonconnect/model/connection_M/user_model.dart';
 
 class EventInvitation extends StatelessWidget {
-  final AppUser inviter;
+  final String inviter;
   final Event event;
   final EventsService _eventsService = EventsService();
 

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -1,5 +1,6 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
+import 'package:gameonconnect/services/events_S/event_service.dart';
 
 class EventInvitation extends StatelessWidget {
   final String inviter;
@@ -35,7 +36,7 @@ class EventInvitation extends StatelessWidget {
             children: [
               FilledButton(
                 onPressed: () {
-      
+                  
                 }, 
                 child: const Text('Accept')),
               FilledButton(

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -1,12 +1,15 @@
 import 'package:expandable/expandable.dart';
 import 'package:flutter/material.dart';
 import 'package:gameonconnect/services/events_S/event_service.dart';
+import 'package:gameonconnect/model/events_M/events_model.dart';
+import 'package:gameonconnect/model/connection_M/user_model.dart';
 
 class EventInvitation extends StatelessWidget {
-  final String inviter;
-  final String eventName;
+  final AppUser inviter;
+  final Event event;
+  final EventsService _eventsService = EventsService();
 
-  const EventInvitation({super.key, required this.inviter, required this.eventName});
+  EventInvitation({super.key, required this.inviter, required this.event});
 
   @override
   Widget build(BuildContext context) {
@@ -22,8 +25,8 @@ class EventInvitation extends StatelessWidget {
               )
             ),
             Text(
-              eventName,
-              style: TextStyle(
+              event.name,
+              style: const TextStyle(
                 fontWeight: FontWeight.bold,
                 color: Colors.green
               )
@@ -36,17 +39,18 @@ class EventInvitation extends StatelessWidget {
             children: [
               FilledButton(
                 onPressed: () {
-                  
+                  _eventsService.joinEvent(event);
                 }, 
                 child: const Text('Accept')),
               FilledButton(
                 onPressed: () {
-      
+                  _eventsService.declineEventInvitation(event);
                 }, 
                 child: const Text('Decline')),
               FilledButton(
                 onPressed: () {
-      
+                  _eventsService.declineEventInvitation(event);
+                  _eventsService.subscribeToEvent(event);
                 }, 
                 child: const Text('Stay notified')),
             ],

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -3,6 +3,7 @@ import 'package:gameonconnect/services/events_S/event_service.dart';
 import 'package:gameonconnect/model/events_M/events_model.dart';
 import 'package:gameonconnect/services/profile_S/profile_service.dart';
 
+// ignore: must_be_immutable
 class EventInvitation extends StatefulWidget {
   final String inviterId;
   final Event event;

--- a/lib/view/components/feed/event_invite.dart
+++ b/lib/view/components/feed/event_invite.dart
@@ -1,0 +1,57 @@
+import 'package:expandable/expandable.dart';
+import 'package:flutter/material.dart';
+
+class EventInvitation extends StatelessWidget {
+  final String inviter;
+  final String eventName;
+
+  const EventInvitation({super.key, required this.inviter, required this.eventName});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ExpansionTile(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '$inviter invited you to join',
+              style: const TextStyle(
+                fontWeight: FontWeight.bold
+              )
+            ),
+            Text(
+              eventName,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.green
+              )
+            )
+          ],
+        ),
+        children: <Widget> [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              FilledButton(
+                onPressed: () {
+      
+                }, 
+                child: const Text('Accept')),
+              FilledButton(
+                onPressed: () {
+      
+                }, 
+                child: const Text('Decline')),
+              FilledButton(
+                onPressed: () {
+      
+                }, 
+                child: const Text('Stay notified')),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/components/feed/event_invite_list.dart
+++ b/lib/view/components/feed/event_invite_list.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:gameonconnect/services/events_S/event_service.dart';
 import 'package:gameonconnect/model/events_M/events_model.dart';
 import 'package:gameonconnect/view/components/feed/event_invite.dart';
-import 'package:gameonconnect/services/profile_S/profile_service.dart';
 
 class EventInvitesList extends StatefulWidget {
   const EventInvitesList({super.key});
@@ -13,7 +12,6 @@ class EventInvitesList extends StatefulWidget {
 
 class _EventInvitesListState extends State<EventInvitesList> {
   final EventsService _eventsService = EventsService();
-  final ProfileService _profileService = ProfileService();
   List<Event> _invitedEvents = [];
 
   @override

--- a/lib/view/components/feed/event_invite_list.dart
+++ b/lib/view/components/feed/event_invite_list.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:gameonconnect/services/events_S/event_service.dart';
+import 'package:gameonconnect/model/events_M/events_model.dart';
+import 'package:gameonconnect/view/components/feed/event_invite.dart';
+
+class EventInvitesList extends StatefulWidget {
+  const EventInvitesList({super.key});
+
+  @override
+  State<EventInvitesList> createState() => _EventInvitesListState();
+}
+
+class _EventInvitesListState extends State<EventInvitesList> {
+  final EventsService _eventsService = EventsService();
+  List<Event> _invitedEvents = [];
+
+  @override
+  void initState() async {
+    super.initState();
+    fetchInvitedEvents();
+  }
+
+  Future<void> fetchInvitedEvents() async {
+    List<Map<String, dynamic>> invitedEvents = await _eventsService.getInvitedEvents();
+
+    setState(() {
+      _invitedEvents = invitedEvents.map((e) => Event.fromMap(e, e['id'])).toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        _invitedEvents.isEmpty ? (Center(child: CircularProgressIndicator())) :
+        ListView.builder(
+          shrinkWrap: true,
+          itemCount: _invitedEvents.length,
+          itemBuilder: (context, index) {
+            return EventInvitation(inviter: _invitedEvents[index].creatorID, event: _invitedEvents[index]);
+          },
+        )
+      ]     
+    );
+  }
+}

--- a/lib/view/components/feed/event_invite_list.dart
+++ b/lib/view/components/feed/event_invite_list.dart
@@ -16,7 +16,7 @@ class _EventInvitesListState extends State<EventInvitesList> {
   List<Event> _invitedEvents = [];
 
   @override
-  void initState() async {
+  void initState() {
     super.initState();
     fetchInvitedEvents();
   }
@@ -31,17 +31,21 @@ class _EventInvitesListState extends State<EventInvitesList> {
 
   @override
   Widget build(BuildContext context) {
-    return ListView(
-      children: [
-        _invitedEvents.isEmpty ? (Center(child: CircularProgressIndicator())) :
-        ListView.builder(
-          shrinkWrap: true,
-          itemCount: _invitedEvents.length,
-          itemBuilder: (context, index) {
-            return EventInvitation(inviter: _invitedEvents[index].creatorID, event: _invitedEvents[index]);
-          },
-        )
-      ]     
+    return Expanded(
+      child: _invitedEvents.isEmpty ? Center(child: CircularProgressIndicator()) : 
+      Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: _invitedEvents.length,
+              itemBuilder: (context, index) {
+                return EventInvitation(inviter: _invitedEvents[index].creatorID, event: _invitedEvents[index]);
+              },
+            ),
+          )
+        ]     
+      ),
     );
   }
 }

--- a/lib/view/components/feed/event_invite_list.dart
+++ b/lib/view/components/feed/event_invite_list.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:gameonconnect/services/events_S/event_service.dart';
 import 'package:gameonconnect/model/events_M/events_model.dart';
 import 'package:gameonconnect/view/components/feed/event_invite.dart';
+import 'package:gameonconnect/services/profile_S/profile_service.dart';
 
 class EventInvitesList extends StatefulWidget {
   const EventInvitesList({super.key});
@@ -13,6 +13,7 @@ class EventInvitesList extends StatefulWidget {
 
 class _EventInvitesListState extends State<EventInvitesList> {
   final EventsService _eventsService = EventsService();
+  final ProfileService _profileService = ProfileService();
   List<Event> _invitedEvents = [];
 
   @override
@@ -32,7 +33,7 @@ class _EventInvitesListState extends State<EventInvitesList> {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: _invitedEvents.isEmpty ? Center(child: CircularProgressIndicator()) : 
+      child: _invitedEvents.isEmpty ? const Text('No new event invites') : 
       Column(
         children: [
           Expanded(
@@ -40,7 +41,7 @@ class _EventInvitesListState extends State<EventInvitesList> {
               shrinkWrap: true,
               itemCount: _invitedEvents.length,
               itemBuilder: (context, index) {
-                return EventInvitation(inviter: _invitedEvents[index].creatorID, event: _invitedEvents[index]);
+                return EventInvitation(inviterId: _invitedEvents[index].creatorID, event: _invitedEvents[index]);
               },
             ),
           )

--- a/lib/view/pages/events/create_events_page.dart
+++ b/lib/view/pages/events/create_events_page.dart
@@ -33,7 +33,7 @@ class _CreateEventsState extends State<CreateEvents> {
   List<String>? invites = [];
 
   Future create() async {
-    await Events().createEvent(
+    await EventsService().createEvent(
         selectedOption,
         _datePicked,
         nameController.text,
@@ -58,14 +58,14 @@ class _CreateEventsState extends State<CreateEvents> {
   }
 
   void getGames() async {
-    games = await Events().getMyGames();
+    games = await EventsService().getMyGames();
     for (var i in games) {
       gameNames.add(i.name);
     }
   }
 
   void getGameID(String gameName)async {
-    games = await Events().getMyGames();
+    games = await EventsService().getMyGames();
     for(var i in games){
       if(i.name == gameName){
         gameID = i.id;
@@ -95,7 +95,7 @@ class _CreateEventsState extends State<CreateEvents> {
             body: SafeArea(
               top: true,
               child: FutureBuilder<List<GameDetails>>(
-                future: Events().getMyGames(),
+                future: EventsService().getMyGames(),
                 builder: (context, snapshot) {
                   if (snapshot.connectionState == ConnectionState.waiting) {
                     return const Center(child: CircularProgressIndicator());

--- a/lib/view/pages/events/invite_connections_page.dart
+++ b/lib/view/pages/events/invite_connections_page.dart
@@ -28,7 +28,7 @@ class _ConnectionsListWidgetState extends State<ConnectionsListWidget> {
   }
 
   Future<void> getConnectionsInvite() async {
-    list = await Events().getConnectionsForInvite();
+    list = await EventsService().getConnectionsForInvite();
   }
 
   @override
@@ -39,7 +39,7 @@ class _ConnectionsListWidgetState extends State<ConnectionsListWidget> {
         body: SafeArea(
           top: true,
           child: FutureBuilder<List<user.AppUser>?>(
-              future: Events().getConnectionsForInvite(),
+              future: EventsService().getConnectionsForInvite(),
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());

--- a/lib/view/pages/events/specific_event_details.dart
+++ b/lib/view/pages/events/specific_event_details.dart
@@ -21,11 +21,11 @@ class _ViewEventDetailsWidgetState extends State<ViewEventDetailsWidget> {
   }
 
   void getImage(String id) async {
-    imageUrl = await Events().getEventImage(e.eventID);
+    imageUrl = await EventsService().getEventImage(e.eventID);
   }
 
   void getUpdatedEvent(String id) async{
-    Event updated = (await Events().getEvent(id))!;
+    Event updated = (await EventsService().getEvent(id))!;
     setState(() {
       e = updated;
     });
@@ -39,7 +39,7 @@ class _ViewEventDetailsWidgetState extends State<ViewEventDetailsWidget> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-        future: Events().getEventImage(e.eventID),
+        future: EventsService().getEventImage(e.eventID),
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());
@@ -47,7 +47,7 @@ class _ViewEventDetailsWidgetState extends State<ViewEventDetailsWidget> {
             return Text('Error: ${snapshot.error}');
           } else {
             imageUrl = snapshot.data!;
-            selected = Events().isSubscribed(e);
+            selected = EventsService().isSubscribed(e);
             return GestureDetector(
               child: Scaffold(
                 backgroundColor: Theme.of(context).colorScheme.surface,
@@ -117,10 +117,10 @@ class _ViewEventDetailsWidgetState extends State<ViewEventDetailsWidget> {
                                       });
                                       if (selected) {
 
-                                        Events().unsubscribeToEvent(e);
+                                        EventsService().unsubscribeToEvent(e);
                                       } else {
 
-                                        Events().subscribeToEvent(e);
+                                        EventsService().subscribeToEvent(e);
                                       }
                                       getUpdatedEvent(e.eventID);
 
@@ -348,7 +348,7 @@ class _ViewEventDetailsWidgetState extends State<ViewEventDetailsWidget> {
                                       ),
                                     ),
                                     Text(
-                                      Events().getAmountJoined(e).toString(),
+                                      EventsService().getAmountJoined(e).toString(),
                                       style: TextStyle(
                                         fontFamily: 'Inter',
                                         color: Theme.of(context)
@@ -393,7 +393,7 @@ class _ViewEventDetailsWidgetState extends State<ViewEventDetailsWidget> {
                                             .fromSTEB(0, 0, 0, 4),
                                         child: MaterialButton(
                                           onPressed: () {
-                                            Events().joinEvent(e);
+                                            EventsService().joinEvent(e);
                                             getUpdatedEvent(e.eventID);
                                           },
                                           child: Text(

--- a/lib/view/pages/events/view_events_page.dart
+++ b/lib/view/pages/events/view_events_page.dart
@@ -15,7 +15,7 @@ class ViewEvents extends StatefulWidget {
 
 class _HomePageWidgetState extends State<ViewEvents> {
   final scaffoldKey = GlobalKey<ScaffoldState>();
-  Events events = Events();
+  EventsService events = EventsService();
   late List<Event>? allEvents;
   late List<Event>? subscribedEvents;
   late List<Event>? myEvents;

--- a/lib/view/pages/feed/feed_page.dart
+++ b/lib/view/pages/feed/feed_page.dart
@@ -15,6 +15,7 @@ import 'package:internet_connection_checker_plus/internet_connection_checker_plu
 // import 'package:gameonconnect/view/pages/events/events_page.dart';
 // import 'package:gameonconnect/services/messaging_S/messaging_service.dart';
 import 'package:gameonconnect/view/pages/events/view_events_page.dart';
+import 'package:gameonconnect/view/components/feed/event_invite_list.dart';
 
 class FeedPage extends StatefulWidget {
   const FeedPage({super.key, required this.title});
@@ -236,7 +237,8 @@ class _FeedPageState extends State<FeedPage> {
           ),
         ],
       ),
-      body: _pages[_selectedIndex], // Display the selected page
+      //body: _pages[_selectedIndex], // Display the selected page
+      body: EventInvitesList(),
       bottomNavigationBar: _buildBottomNavigationBar(),
     );
   }

--- a/lib/view/pages/feed/feed_page.dart
+++ b/lib/view/pages/feed/feed_page.dart
@@ -15,7 +15,6 @@ import 'package:internet_connection_checker_plus/internet_connection_checker_plu
 // import 'package:gameonconnect/view/pages/events/events_page.dart';
 // import 'package:gameonconnect/services/messaging_S/messaging_service.dart';
 import 'package:gameonconnect/view/pages/events/view_events_page.dart';
-import 'package:gameonconnect/view/components/feed/event_invite_list.dart';
 
 class FeedPage extends StatefulWidget {
   const FeedPage({super.key, required this.title});
@@ -237,8 +236,7 @@ class _FeedPageState extends State<FeedPage> {
           ),
         ],
       ),
-      //body: _pages[_selectedIndex], // Display the selected page
-      body: EventInvitesList(),
+      body: _pages[_selectedIndex], // Display the selected page
       bottomNavigationBar: _buildBottomNavigationBar(),
     );
   }

--- a/lib/view/pages/profile/connections_list.dart
+++ b/lib/view/pages/profile/connections_list.dart
@@ -29,7 +29,7 @@ class _ConnectionsListState extends State<ConnectionsList> {
   }
 
   Future<void> getConnectionsInvite() async {
-    list = await Events().getConnectionsForInvite();
+    list = await EventsService().getConnectionsForInvite();
     setState(() {});
   }
 
@@ -51,7 +51,7 @@ class _ConnectionsListState extends State<ConnectionsList> {
     ),
     
       body:  FutureBuilder<List<user.AppUser>?>(
-              future: Events().getConnectionsForInvite(),
+              future: EventsService().getConnectionsForInvite(),
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());


### PR DESCRIPTION
This code allows users to see a list of events other users invite the current user to.  The three buttons do the following:
1. Accept - Accepts the invitation and moves the user's ID from the invited array to the joined array in the database.
2. Decline - Declines the event invitation and removes the user's uid from the invited array in the database
3. Stay notified - The user subscribes to the event rather than joining and moves the user's uid from the invited array to the subscribed array.

Steps to test:
1. Comment out the current body on the feed page
2. Add the EventInvitesList component to the body of the feed page
3. Run the app with a user who is invited to a few events.

(I know the UI looks super ugly for now.  But I will change that in a separate branch)