### PR TITLE
Feat/message-cleanup-into-Develop

### DIFF
--- a/lib/services/messaging_S/messaging_service.dart
+++ b/lib/services/messaging_S/messaging_service.dart
@@ -114,6 +114,24 @@ class MessagingService {
     });
   }
 
+  /*Stream<List<Map<String, dynamic>>> getAllChatsForCurrentUser() async* {
+  final User? currentUser = _auth.currentUser;
+  var allUsersSnapshot = await _firestore.collection("profile_data").get();
+  List<Map<String, dynamic>> allUsers = allUsersSnapshot.docs
+      .map((doc) => doc.data())
+      .toList();
+
+  List<Map<String, dynamic>> usersWithConversations = [];
+  for (var user in allUsers) {
+    String conversationID = await findConversationID( user['userID'],currentUser!.uid,);
+    if (conversationID != 'Not found') {
+      usersWithConversations.add(user);
+    }
+  }
+
+  yield usersWithConversations;
+}*/
+
   Future<String> findConversationID(String userID1, String userID2) async {
     var querySnapshot = await _firestore
         .collection('message_log')

--- a/lib/services/messaging_S/messaging_service.dart
+++ b/lib/services/messaging_S/messaging_service.dart
@@ -5,7 +5,7 @@ import 'package:gameonconnect/model/messages_M/message_modal.dart';
 class MessagingService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
-
+  
   // Create a new conversation (group or private chat)
   Future<String> createConversation(List<String> participants) async {
     try {

--- a/lib/services/messaging_S/messaging_service.dart
+++ b/lib/services/messaging_S/messaging_service.dart
@@ -5,7 +5,7 @@ import 'package:gameonconnect/model/messages_M/message_modal.dart';
 class MessagingService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
-  
+
   // Create a new conversation (group or private chat)
   Future<String> createConversation(List<String> participants) async {
     try {
@@ -77,11 +77,11 @@ class MessagingService {
   }
 
   Stream<QuerySnapshot> getSnapshotMessages(String conversationID) {
-  return FirebaseFirestore.instance
-      .collection('messages')
-      .where('conversationID', isEqualTo: conversationID)
-      .orderBy('timestamp', descending: false)
-      .snapshots();
+    return FirebaseFirestore.instance
+        .collection('messages')
+        .where('conversationID', isEqualTo: conversationID)
+        .orderBy('timestamp', descending: false)
+        .snapshots();
   }
 
   // Get conversations for the current user
@@ -114,40 +114,42 @@ class MessagingService {
     });
   }
 
-  /*Stream<List<Map<String, dynamic>>> getAllChatsForCurrentUser() async* {
-  final User? currentUser = _auth.currentUser;
-  var allUsersSnapshot = await _firestore.collection("profile_data").get();
-  List<Map<String, dynamic>> allUsers = allUsersSnapshot.docs
-      .map((doc) => doc.data())
-      .toList();
+  Stream<List<Map<String, dynamic>>> getAllChatsForCurrentUser() async* {
+    final User? currentUser = _auth.currentUser; //get the current user
+    var allUsersSnapshot = await _firestore.collection("profile_data").get();
+    List<Map<String, dynamic>> allUsers =
+        allUsersSnapshot.docs.map((doc) => doc.data()).toList(); //map the users t a list
 
-  List<Map<String, dynamic>> usersWithConversations = [];
-  for (var user in allUsers) {
-    String conversationID = await findConversationID( user['userID'],currentUser!.uid,);
-    if (conversationID != 'Not found') {
-      usersWithConversations.add(user);
+    List<Map<String, dynamic>> usersWithConversations = [];
+    for (var user in allUsers) {
+      String conversationID = await findConversationID(
+        user['userID'],
+        currentUser!.uid,
+      ); //find the conversationID between all the users and the person logged in
+      if (conversationID != 'Not found') {
+        usersWithConversations.add(user);
+      }
     }
-  }
 
-  yield usersWithConversations;
-}*/
+    yield usersWithConversations; //yield the results
+  }
 
   Future<String> findConversationID(String userID1, String userID2) async {
     var querySnapshot = await _firestore
         .collection('message_log')
         .where('participants', arrayContains: userID1)
         .get();
-    
+
     for (var doc in querySnapshot.docs) {
-    var participants = List<String>.from(doc['participants']);
-    if (participants.contains(userID2) && participants.contains(userID1) && userID1 != userID2) {
-      return doc.id; 
+      var participants = List<String>.from(doc['participants']);
+      if (participants.contains(userID2) &&
+          participants.contains(userID1) &&
+          userID1 != userID2) {
+        return doc.id;
+      }
     }
-  }
     return 'Not found';
   }
-
-  
 }
 
 /* 

--- a/lib/services/messaging_S/messaging_service.dart
+++ b/lib/services/messaging_S/messaging_service.dart
@@ -104,6 +104,51 @@ class MessagingService {
     }
   }
 
+  Future<DocumentSnapshot> getLastMessage(String userID, String otherUserID) async {
+  try {
+    //check that the userid and otheruser is not empty
+    if (userID.isEmpty || otherUserID.isEmpty || otherUserID == 'Not Found' || userID == 'Not Found') {
+      throw Exception("No user logged in");
+    }
+    String conversationID = await findConversationID(userID, otherUserID); //now get the conversationID
+    DocumentSnapshot conversationSnapshot = await _firestore //get the conversation from the messagelog
+        .collection('message_log')
+        .doc(conversationID)
+        .get();
+    
+    //ensure the conversation is found
+    if (!conversationSnapshot.exists) {
+      throw Exception("Conversation was not found");
+    }
+
+    //map the data so that the participant messages can be extracted
+    Map<String, dynamic> conversationData = conversationSnapshot.data() as Map<String, dynamic>;
+    List<dynamic> participantMessages = conversationData['participant_messages']; //store messages in a list
+
+    //ensure the participant messages are not empty 
+    if (participantMessages.isEmpty) {
+      throw Exception("No messages in conversation found");
+    }
+
+    //take the last messageID available
+    String lastMessageID = participantMessages.last;
+    //get a snapshot 
+    DocumentSnapshot messageSnapshot = await _firestore
+        .collection('messages')
+        .doc(lastMessageID)
+        .get();
+
+    //check that the snapshot exists
+    if (!messageSnapshot.exists) {
+      throw Exception("Message was not found");
+    }
+    //return the last message as a snapshot
+    return messageSnapshot;
+  } catch (e) {
+    throw Exception("Failed to get last message: $e");
+  }
+}
+
   Stream<List<Map<String, dynamic>>> getAllUsers() {
     //can change this later to get less users
     return _firestore.collection("profile_data").snapshots().map((snapshot) {
@@ -117,8 +162,9 @@ class MessagingService {
   Stream<List<Map<String, dynamic>>> getAllChatsForCurrentUser() async* {
     final User? currentUser = _auth.currentUser; //get the current user
     var allUsersSnapshot = await _firestore.collection("profile_data").get();
-    List<Map<String, dynamic>> allUsers =
-        allUsersSnapshot.docs.map((doc) => doc.data()).toList(); //map the users t a list
+    List<Map<String, dynamic>> allUsers = allUsersSnapshot.docs
+        .map((doc) => doc.data())
+        .toList(); //map the users to a list
 
     List<Map<String, dynamic>> usersWithConversations = [];
     for (var user in allUsers) {

--- a/lib/view/components/card/connection_list_card.dart
+++ b/lib/view/components/card/connection_list_card.dart
@@ -4,18 +4,19 @@ import 'package:delightful_toast/toast/utils/enums.dart';
 import 'package:flutter/material.dart';
 import 'package:gameonconnect/services/connection_S/connection_service.dart';
 import 'package:gameonconnect/view/components/card/custom_toast_card.dart';
+import 'package:gameonconnect/view/pages/messaging/chat_page.dart';
 import 'package:gameonconnect/view/pages/messaging/messaging_page.dart';
 
 class ConnectionCardWidget extends StatefulWidget {
-  final String image ;
+  final String image;
   final String username;
-  final String uniqueNum ;
-  final String uid ;
+  final String uniqueNum;
+  final String uid;
   final String page;
-  final void Function(String uid,bool selected) onSelected;
+  final void Function(String uid, bool selected) onSelected;
   final void Function(String uid)? onDisconnected;
   final void Function(String uid)? onAccepted;
-   final void Function(String uid)? onRejected;
+  final void Function(String uid)? onRejected;
 
   const ConnectionCardWidget({
     super.key,
@@ -25,9 +26,9 @@ class ConnectionCardWidget extends StatefulWidget {
     required this.uniqueNum,
     required this.onSelected,
     required this.page,
-     this.onDisconnected, 
-     this.onAccepted,
-     this.onRejected,
+    this.onDisconnected,
+    this.onAccepted,
+    this.onRejected,
   });
 
   @override
@@ -35,34 +36,34 @@ class ConnectionCardWidget extends StatefulWidget {
 }
 
 class _ConnectionCardWidgetState extends State<ConnectionCardWidget> {
-late String image;
-late String username;
-late String uniqueNum;
-late String uid;
-late String page;
-bool selected = false;
+  late String image;
+  late String username;
+  late String uniqueNum;
+  late String uid;
+  late String page;
+  bool selected = false;
 
-@override
-void initState() {
-  super.initState();
-  image = widget.image;
-  username = widget.username;
-  uniqueNum = widget.uniqueNum;
-  uid = widget.uid;
-  page=widget.page;
-}
+  @override
+  void initState() {
+    super.initState();
+    image = widget.image;
+    username = widget.username;
+    uniqueNum = widget.uniqueNum;
+    uid = widget.uid;
+    page = widget.page;
+  }
 
-@override
-void dispose() {
-  super.dispose();
-}
+  @override
+  void dispose() {
+    super.dispose();
+  }
 
-
-void _disconnect(String targetUserId) async {
+  void _disconnect(String targetUserId) async {
     try {
-      await ConnectionService().disconnect( targetUserId);
-       if (widget.onDisconnected != null) {
-        widget.onDisconnected!(targetUserId); // Notify parent widget if callback is provided
+      await ConnectionService().disconnect(targetUserId);
+      if (widget.onDisconnected != null) {
+        widget.onDisconnected!(
+            targetUserId); // Notify parent widget if callback is provided
       }
     } catch (e) {
       //'Error unfollowing user'
@@ -89,9 +90,10 @@ void _disconnect(String targetUserId) async {
 
   void _accept(String targetUserId) async {
     try {
-      await ConnectionService().acceptConnectionRequest( targetUserId);
-       if (widget.onAccepted != null) {
-        widget.onAccepted!(targetUserId); // Notify parent widget if callback is provided
+      await ConnectionService().acceptConnectionRequest(targetUserId);
+      if (widget.onAccepted != null) {
+        widget.onAccepted!(
+            targetUserId); // Notify parent widget if callback is provided
       }
     } catch (e) {
       //'Error unfollowing user'
@@ -118,9 +120,10 @@ void _disconnect(String targetUserId) async {
 
   void _reject(String targetUserId) async {
     try {
-      await ConnectionService().rejectConnectionRequest( targetUserId);
-       if (widget.onRejected != null) {
-        widget.onRejected!(targetUserId); // Notify parent widget if callback is provided
+      await ConnectionService().rejectConnectionRequest(targetUserId);
+      if (widget.onRejected != null) {
+        widget.onRejected!(
+            targetUserId); // Notify parent widget if callback is provided
       }
     } catch (e) {
       //'Error unfollowing user'
@@ -145,182 +148,186 @@ void _disconnect(String targetUserId) async {
     }
   }
 
-
-
   @override
-Widget build(BuildContext context) {
-  Widget cardContent = Container(
-    width: 388,
-    height: 72,
-    decoration: BoxDecoration(
-      color: selected ? Theme.of(context).colorScheme.primary : Theme.of(context).colorScheme.surface,
-      boxShadow: [
-        BoxShadow(
-          blurRadius: 0,
-          color: Theme.of(context).colorScheme.surface,
-          offset: const Offset(0, 1),
-        )
-      ],
-    ),
-    child: Padding(
-      padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 0),
-      child: Row(
-        mainAxisSize: MainAxisSize.max,
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          // Profile picture and name column
-          Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.start,
-            children: [
-              Container(
-                width: 44,
-                height: 44,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  border: (page != "events")
-                      ? null // No border for profiles
-                      : Border.all(
-                          width: 1, // Add a border for non-profiles
-                          color: Colors.black,
-                        ),
-                ),
-                child: Padding(
-                  padding: const EdgeInsets.all(2),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(44),
-                    
-                    child: CachedNetworkImage(
-                              imageUrl: image,
-                              placeholder: (context, url) => const Center(child: CircularProgressIndicator()), // Loading indicator for banner
-                              errorWidget: (context, url, error) => const Icon(Icons.error),
-                              fit: BoxFit.cover,
-                            ),
-                  ),
-                ),
-              ),
-              const SizedBox(width: 12), // Add spacing between profile picture and name
-              Column(
-                mainAxisSize: MainAxisSize.max,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    username,
-                    style: TextStyle(
-                      fontFamily: 'Inter',
-                      color: Theme.of(context).colorScheme.secondary,
-                      fontSize: 16,
-                      letterSpacing: 0,
-                      fontWeight: FontWeight.normal,
-                    ),
-                  ),
-                  Text(
-                    '# $uniqueNum',
-                    style: TextStyle(
-                      fontFamily: 'Inter',
-                      color: Theme.of(context).colorScheme.secondary,
-                      fontSize: 14,
-                      letterSpacing: 0,
-                      fontWeight: FontWeight.normal,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          // Popup menu button
-          if (page == 'connections')
-            PopupMenuButton<String>(
-              itemBuilder: (context) => [
-                const PopupMenuItem<String>(
-                  value: 'disconnect',
-                  child: Text('Disconnect'),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'message',
-                  child: Text('Message'),
-                ),
-              ],
-              onSelected: (value) {
-                if (value == 'disconnect') {
-                  _disconnect(uid);
-                } else if (value == 'message') {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const Messaging(),
-                    ),
-                  );
-                }
-              },
-            )
-          else if (page == 'requests')
-            PopupMenuButton<String>(
-              itemBuilder: (context) => [
-                const PopupMenuItem<String>(
-                  value: 'accept',
-                  child: Row(
-                    children: [
-                      Text('Accept'),
-                      Icon(
-                        Icons.check,
-                        color: Colors.green,
-                      ),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'reject',
-                  child: Row(
-                    children: [
-                      Text('Reject'),
-                      Icon(
-                        Icons.close,
-                        color: Colors.red,
-                      ),
-                    ],
-                  ),
-                ),
-                const PopupMenuItem<String>(
-                  value: 'message',
-                  child: Text('Message'),
-                ),
-              ],
-              onSelected: (value) {
-                if (value == 'accept') {
-                  _accept(uid );
-                } else if (value == 'reject') {
-                  _reject(uid);
-                } else if (value == 'message') {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => const Messaging(),
-                    ),
-                  );
-                }
-              },
-            ),
+  Widget build(BuildContext context) {
+    Widget cardContent = Container(
+      width: 388,
+      height: 72,
+      decoration: BoxDecoration(
+        color: selected
+            ? Theme.of(context).colorScheme.primary
+            : Theme.of(context).colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            blurRadius: 0,
+            color: Theme.of(context).colorScheme.surface,
+            offset: const Offset(0, 1),
+          )
         ],
       ),
-    ),
-  );
-
-  if (page == 'events') {
-    return GestureDetector(
-      onTap: () {
-        setState(() {
-          selected = !selected;
-        });
-        widget.onSelected(uid, selected);
-      },
-      child: cardContent,
+      child: Padding(
+        padding: const EdgeInsetsDirectional.fromSTEB(16, 0, 16, 0),
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            // Profile picture and name column
+            Row(
+              mainAxisSize: MainAxisSize.max,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+                Container(
+                  width: 44,
+                  height: 44,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    border: (page != "events")
+                        ? null // No border for profiles
+                        : Border.all(
+                            width: 1, // Add a border for non-profiles
+                            color: Colors.black,
+                          ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(2),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(44),
+                      child: CachedNetworkImage(
+                        imageUrl: image,
+                        placeholder: (context, url) => const Center(
+                            child:
+                                CircularProgressIndicator()), // Loading indicator for banner
+                        errorWidget: (context, url, error) =>
+                            const Icon(Icons.error),
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(
+                    width: 12), // Add spacing between profile picture and name
+                Column(
+                  mainAxisSize: MainAxisSize.max,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      username,
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        color: Theme.of(context).colorScheme.secondary,
+                        fontSize: 16,
+                        letterSpacing: 0,
+                        fontWeight: FontWeight.normal,
+                      ),
+                    ),
+                    Text(
+                      '# $uniqueNum',
+                      style: TextStyle(
+                        fontFamily: 'Inter',
+                        color: Theme.of(context).colorScheme.secondary,
+                        fontSize: 14,
+                        letterSpacing: 0,
+                        fontWeight: FontWeight.normal,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            // Popup menu button
+            if (page == 'connections')
+              PopupMenuButton<String>(
+                itemBuilder: (context) => [
+                  const PopupMenuItem<String>(
+                    value: 'disconnect',
+                    child: Text('Disconnect'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'message',
+                    child: Text('Message'),
+                  ),
+                ],
+                onSelected: (value) {
+                  if (value == 'disconnect') {
+                    _disconnect(uid);
+                  } else if (value == 'message') {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ChatPage(
+                          profileName: username,
+                          receiverID: uid,
+                        ),
+                      ),
+                    );
+                  }
+                },
+              )
+            else if (page == 'requests')
+              PopupMenuButton<String>(
+                itemBuilder: (context) => [
+                  const PopupMenuItem<String>(
+                    value: 'accept',
+                    child: Row(
+                      children: [
+                        Text('Accept'),
+                        Icon(
+                          Icons.check,
+                          color: Colors.green,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'reject',
+                    child: Row(
+                      children: [
+                        Text('Reject'),
+                        Icon(
+                          Icons.close,
+                          color: Colors.red,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'message',
+                    child: Text('Message'),
+                  ),
+                ],
+                onSelected: (value) {
+                  if (value == 'accept') {
+                    _accept(uid);
+                  } else if (value == 'reject') {
+                    _reject(uid);
+                  } else if (value == 'message') {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const Messaging(),
+                      ),
+                    );
+                  }
+                },
+              ),
+          ],
+        ),
+      ),
     );
-  } else {
-    return cardContent;
+
+    if (page == 'events') {
+      return GestureDetector(
+        onTap: () {
+          setState(() {
+            selected = !selected;
+          });
+          widget.onSelected(uid, selected);
+        },
+        child: cardContent,
+      );
+    } else {
+      return cardContent;
+    }
   }
-}
-
-
 }

--- a/lib/view/components/messaging/chat_bubble_component.dart
+++ b/lib/view/components/messaging/chat_bubble_component.dart
@@ -31,12 +31,13 @@ class ChatBubble extends StatelessWidget {
           Text(
             message,
             style: TextStyle(
+              fontSize: 20,
               color: Theme.of(context).colorScheme.surface,
               fontWeight: FontWeight.bold
             ),
           ),
           Text(
-            DateFormat('hh:mm a').format(dateTime),
+            DateFormat('yyyy/MM/dd – kk:mm').format(dateTime),
             style: TextStyle(
               fontSize: 11,
               color: Theme.of(context).colorScheme.surface,

--- a/lib/view/components/messaging/user_tile.dart
+++ b/lib/view/components/messaging/user_tile.dart
@@ -5,19 +5,21 @@ import 'package:flutter/material.dart';
 import 'package:gameonconnect/model/profile_M/profile_model.dart';
 import 'package:gameonconnect/services/profile_S/profile_service.dart';
 import 'package:gameonconnect/view/components/card/custom_toast_card.dart';
-//import 'package:gameonconnect/view/pages/messaging/chat_page.dart';
 
 class UserTile extends StatefulWidget {
   final String text;
   final void Function()? onTap;
   final String profilepictureURL;
+  final String lastMessage;
+  final String time;
 
-  //here we will require more data to be passed in. 
   const UserTile({
     super.key,
     required this.text,
     required this.onTap,
     required this.profilepictureURL,
+    required this.lastMessage,
+    required this.time,
   });
 
   @override
@@ -137,7 +139,7 @@ class _UserTileState extends State<UserTile> {
                                         padding: const EdgeInsetsDirectional
                                             .fromSTEB(0, 4, 0, 0),
                                         child: Text(
-                                          'This was really great, i\'m so glad that we could  catchup this weekend.',
+                                          widget.lastMessage, //this text needs to change to the passed in text
                                           textAlign: TextAlign.start,
                                           style: TextStyle(
                                             fontFamily: 'Inter',
@@ -159,7 +161,7 @@ class _UserTileState extends State<UserTile> {
                                             padding: const EdgeInsetsDirectional
                                                 .fromSTEB(0, 4, 0, 0),
                                             child: Text(
-                                              '9:55pm',
+                                              widget.time,
                                               textAlign: TextAlign.start,
                                               style: TextStyle(
                                                 fontFamily: 'Inter',

--- a/lib/view/pages/feed/feed_page.dart
+++ b/lib/view/pages/feed/feed_page.dart
@@ -212,11 +212,6 @@ class _FeedPageState extends State<FeedPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        title: Text(widget.title,
-            style: TextStyle(color: Theme.of(context).colorScheme.surface)),
-      ),
       body: _pages[_selectedIndex], // Display the selected page
       bottomNavigationBar: _buildBottomNavigationBar(),
     );

--- a/lib/view/pages/feed/feed_page.dart
+++ b/lib/view/pages/feed/feed_page.dart
@@ -216,25 +216,6 @@ class _FeedPageState extends State<FeedPage> {
         backgroundColor: Theme.of(context).colorScheme.primary,
         title: Text(widget.title,
             style: TextStyle(color: Theme.of(context).colorScheme.surface)),
-        actions: <Widget>[
-          Padding(
-            padding: const EdgeInsets.only(right: 20.0),
-            child: IconButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => const Messaging(),
-                  ),
-                );
-              },
-              icon: Icon(
-                Icons.message,
-                color: Theme.of(context).colorScheme.surface,
-                ),
-            ),
-          ),
-        ],
       ),
       body: _pages[_selectedIndex], // Display the selected page
       bottomNavigationBar: _buildBottomNavigationBar(),
@@ -310,35 +291,59 @@ class _DevelopmentButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          MaterialButton(
-            onPressed: () {
-              // Get the current user's ID
-              String? currentUserId = FirebaseAuth.instance.currentUser?.uid;
-              //print("current user from home: $currentUserId");
-              if (currentUserId != null) {
-                // Pass the current user's ID to the search friends page
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Feed'),
+        actions: <Widget>[
+          Padding(
+            padding: const EdgeInsets.only(right: 20.0),
+            child: IconButton(
+              onPressed: () {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
-                    //builder: (context) => FriendSearchPage(currentUserId),
-                    builder: (context) => FriendSearch(),
+                    builder: (context) => const Messaging(),
                   ),
                 );
-              } else {
-                // Handle the case where there is no logged-in user
-                // ignore: avoid_print
-                print('No user is currently logged in.');
-              }
-            },
-            color: Theme.of(context).colorScheme.primary,
-            textColor: Theme.of(context).colorScheme.surface,
-            child: const Text('search friends '),
+              },
+              icon: Icon(
+                Icons.message,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
+            ),
           ),
         ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            MaterialButton(
+              onPressed: () {
+                // Get the current user's ID
+                String? currentUserId = FirebaseAuth.instance.currentUser?.uid;
+                //print("current user from home: $currentUserId");
+                if (currentUserId != null) {
+                  // Pass the current user's ID to the search friends page
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      //builder: (context) => FriendSearchPage(currentUserId),
+                      builder: (context) => FriendSearch(),
+                    ),
+                  );
+                } else {
+                  // Handle the case where there is no logged-in user
+                  // ignore: avoid_print
+                  print('No user is currently logged in.');
+                }
+              },
+              color: Theme.of(context).colorScheme.primary,
+              textColor: Theme.of(context).colorScheme.surface,
+              child: const Text('search friends '),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/pages/messaging/messaging_page.dart
+++ b/lib/view/pages/messaging/messaging_page.dart
@@ -59,6 +59,7 @@ class _MessagingState extends State<Messaging> {
   //build user list
   Widget _buildUserList() {
     return StreamBuilder(
+      //stream: _messagingService.getAllChatsForCurrentUser(), possible fix
       stream: _messagingService.getAllUsers(),
       builder: (context, snapshot) {
         if (snapshot.hasError) {

--- a/lib/view/pages/messaging/messaging_page.dart
+++ b/lib/view/pages/messaging/messaging_page.dart
@@ -1,15 +1,14 @@
-//import 'package:delightful_toast/delight_toast.dart';
-//import 'package:delightful_toast/toast/utils/enums.dart';
+import 'package:delightful_toast/delight_toast.dart';
+import 'package:delightful_toast/toast/utils/enums.dart';
 //import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:gameonconnect/services/authentication_S/auth_service.dart';
 //import 'package:gameonconnect/model/profile_M/profile_model.dart';
 import 'package:gameonconnect/services/messaging_S/messaging_service.dart';
 import 'package:gameonconnect/services/profile_S/storage_service.dart';
-//import 'package:gameonconnect/services/profile_S/storage_service.dart';
 //import 'package:gameonconnect/services/profile_S/profile_service.dart';
 //import 'package:cached_network_image/cached_network_image.dart';
-//import 'package:gameonconnect/view/components/card/custom_toast_card.dart';
+import 'package:gameonconnect/view/components/card/custom_toast_card.dart';
 import 'package:gameonconnect/view/components/messaging/user_tile.dart';
 import 'package:gameonconnect/view/pages/messaging/chat_page.dart';
 
@@ -59,15 +58,39 @@ class _MessagingState extends State<Messaging> {
   //build user list
   Widget _buildUserList() {
     return StreamBuilder(
-      //stream: _messagingService.getAllChatsForCurrentUser(), possible fix
-      stream: _messagingService.getAllUsers(),
+      stream: _messagingService
+          .getAllChatsForCurrentUser(), //get the existing chats
       builder: (context, snapshot) {
         if (snapshot.hasError) {
-          return const Text('error');
+          DelightToastBar( 
+                  builder: (context) {
+                    return CustomToastCard(
+                      title: Text(
+                        'Check your internet connection',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                    );
+                  },
+                  position: DelightSnackbarPosition.top,
+                  autoDismiss: true,
+                  snackbarDuration: const Duration(seconds: 3))
+              .show(
+            context,
+          );
+          return const Text('An unexpected error occurred.');
         }
 
         if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Text('loading');
+          return const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CircularProgressIndicator(), //put a circular progress bar in the center
+              ],
+            ),
+          );
         }
 
         return ListView(
@@ -87,10 +110,10 @@ class _MessagingState extends State<Messaging> {
     String userID = userData['userID'] as String? ?? "default_picture_url";
     String receiverID = userData['userID'] as String? ?? "default_user_id";
     return FutureBuilder<String>(
-      future: storageService
-          .getProfilePictureUrl(userID), 
+      future: storageService.getProfilePictureUrl(userID),
       builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) { //this is the loading state
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          //this is the loading state
           return Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
@@ -101,18 +124,20 @@ class _MessagingState extends State<Messaging> {
                   child: CircularProgressIndicator(),
                 ),
               ),
-              Divider( //added divider here to induce the same loading
-                    height: 1,
-                    thickness: 0.5,
-                    color: Theme.of(context).colorScheme.secondary,
-              ), 
+              Divider(
+                //added divider here to induce the same loading
+                height: 1,
+                thickness: 0.5,
+                color: Theme.of(context).colorScheme.secondary,
+              ),
             ],
           );
         } else if (snapshot.hasError) {
           //add a possible toastbar to check the connection
-          return const Icon(Icons.error_outline); 
+          return const Icon(Icons.error_outline);
           //Text('Error: ${snapshot.error}'
-        } else { //this widget means that the data loaded successfully
+        } else {
+          //this widget means that the data loaded successfully
           String profilePictureUrl = snapshot.data!;
           if (userData['userID'] != _authService.getCurrentUser()!.uid) {
             return UserTile(


### PR DESCRIPTION
Various Quality of life improvements on the messaging.

1. The profile images now load via the storage service.
2. The message page now only loads the chats with users you have sent messages before. 
3. You can now send messages to connections via viewing your connections
4. You can now also see the last message sent in the chat on the message page. 
5. The chat bubbles now show the time and date that the messages were sent. I increased the font size on the messages to be able to distinguish between time sent and the message itself. 

Please check if you can send a message to a new connection via the connections and then that it loads in the messaging page. 
Also note it does not include group messaging yet. I will add that in a future new pull request when this is in Develop.
Also note the RAWG API does not work on this branch, because this branch was made before that fix. 
 
A few features to enhance the messaging in the future could possibly be: 
-Adding a green/colored indicator to indicate a new message is viewable
-Adding a feature to delete a specific message or a whole chat. 
-Showing the user profile image included in the chat page as well (not only the profile name)
-ability to block a user
-possibly sending images/videos (although I would hold off on this unless absolutely necessary)

