### PR TITLE
Feat/message cleanup2 into Develop

### DIFF
--- a/lib/view/components/appbars/backbutton_appbar_component.dart
+++ b/lib/view/components/appbars/backbutton_appbar_component.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class BackButtonAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final VoidCallback onBackButtonPressed;
+  final Key iconkey;
+  final Key textkey;
+
+  const BackButtonAppBar({
+    super.key,
+    required this.title,
+    required this.onBackButtonPressed,
+    required this.iconkey,
+    required this.textkey,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      automaticallyImplyLeading: false,
+      leading: IconButton(
+        key: iconkey,
+        icon: Icon(
+          Icons.arrow_back,
+          color: Theme.of(context).colorScheme.secondary,
+        ),
+        onPressed: onBackButtonPressed,
+      ),
+      title: Text(
+        key: textkey,
+        title,
+        style: TextStyle(
+          fontSize: 32,
+          fontWeight: FontWeight.bold,
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/view/components/messaging/chat_bubble_component.dart
+++ b/lib/view/components/messaging/chat_bubble_component.dart
@@ -20,8 +20,8 @@ class ChatBubble extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: isCurrentuser
-            ? Theme.of(context).colorScheme.primary
-            : const Color.fromARGB(255, 107, 188, 255),
+            ? Theme.of(context).colorScheme.tertiary
+            : Theme.of(context).colorScheme.primaryContainer,
         borderRadius: BorderRadius.circular(17),
       ),
       padding: const EdgeInsets.all(12),
@@ -32,15 +32,16 @@ class ChatBubble extends StatelessWidget {
             message,
             style: TextStyle(
               fontSize: 20,
-              color: Theme.of(context).colorScheme.surface,
-              fontWeight: FontWeight.bold
+              color: Theme.of(context).colorScheme.onSurface,
+              fontWeight: FontWeight.w700
             ),
           ),
           Text(
             DateFormat('yyyy/MM/dd – kk:mm').format(dateTime),
             style: TextStyle(
               fontSize: 11,
-              color: Theme.of(context).colorScheme.surface,
+              color: Theme.of(context).colorScheme.onSurface,
+              fontWeight: FontWeight.w500
             ),
           ),
         ],

--- a/lib/view/components/messaging/user_tile.dart
+++ b/lib/view/components/messaging/user_tile.dart
@@ -105,11 +105,6 @@ class _UserTileState extends State<UserTile> {
                                 decoration: BoxDecoration(
                                   color: Theme.of(context).colorScheme.surface,
                                   shape: BoxShape.circle,
-                                  border: Border.all(
-                                    color:
-                                        Theme.of(context).colorScheme.primary,
-                                    width: 2,
-                                  ),
                                 ),
                                 child: buildProfilePicture(widget.profilepictureURL), //build the profile picture widget
                               ),
@@ -132,7 +127,7 @@ class _UserTileState extends State<UserTile> {
                                               .secondary,
                                           fontSize: 20,
                                           letterSpacing: 0,
-                                          fontWeight: FontWeight.w500,
+                                          fontWeight: FontWeight.w900
                                         ),
                                       ),
                                       Padding(
@@ -148,7 +143,7 @@ class _UserTileState extends State<UserTile> {
                                                 .secondary,
                                             fontSize: 15,
                                             letterSpacing: 0,
-                                            fontWeight: FontWeight.w500,
+                                            fontWeight: FontWeight.w700,
                                           ),
                                         ),
                                       ),
@@ -170,7 +165,7 @@ class _UserTileState extends State<UserTile> {
                                                     .secondary,
                                                 fontSize: 10,
                                                 letterSpacing: 0,
-                                                fontWeight: FontWeight.w500,
+                                                fontWeight: FontWeight.w600,
                                               ),
                                             ),
                                           ),

--- a/lib/view/pages/events/view_events_page.dart
+++ b/lib/view/pages/events/view_events_page.dart
@@ -34,10 +34,9 @@ class _HomePageWidgetState extends State<ViewEvents> {
 
   void getAllEvents() async {
     //allEvents =  events.fetchAllEvents() as List<Event>?;
-    subscribedEvents= events.getSubscribedEvents(allEvents );
-    myEvents = events.getMyEvents(allEvents );
+    subscribedEvents = events.getSubscribedEvents(allEvents);
+    myEvents = events.getMyEvents(allEvents);
     joinedEvents = events.getJoinedEvents(allEvents);
-
   }
 
   @override
@@ -58,363 +57,383 @@ class _HomePageWidgetState extends State<ViewEvents> {
                       } else {
                         allEvents = snapshot.data;
                         getAllEvents();
-                        return SingleChildScrollView(child:  DefaultTabController(
-                          length: 3,
-                          child: Wrap( children: [Column(
-
-                            mainAxisSize: MainAxisSize.max,
-                            children: [
-                              Align(
-                                alignment: const AlignmentDirectional(-1, 0),
-                                child: Padding(
-                                  padding: const EdgeInsetsDirectional.fromSTEB(
-                                      16, 5, 0, 0),
-                                  child: Text(
-                                    'Events:',
-                                    textAlign: TextAlign.start,
-                                    style: TextStyle(
-                                      fontFamily: 'Inter',
-                                      letterSpacing: 0,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .secondary,
-                                      fontSize: 32,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                              Padding(
-                                padding: const EdgeInsetsDirectional.fromSTEB(
-                                    0, 12, 0, 0),
-                                child: SizedBox(
-                                  width: double.infinity,
-                                  height: 150,
-                                  child: CarouselSlider.builder(
-                                    itemCount: joinedEvents?.length,
-                                    carouselController: CarouselController(),
-                                    options: CarouselOptions(
-                                      initialPage: 0,
-                                      viewportFraction: 0.5,
-                                      disableCenter: true,
-                                      enlargeCenterPage: true,
-                                      enlargeFactor: 0.25,
-                                      enableInfiniteScroll: false,
-                                      scrollDirection: Axis.horizontal,
-                                      autoPlay: false,
-                                    ), itemBuilder: (context,index,realIndex) {
-                                    Event i =
-                                    joinedEvents![index];
-                                    return UpcomingEventCardWidget(
-                                        e: i);
-                                  },
-                                  ),
-                                ),
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.all(16),
-                                child: Container(
-                                  width: 430,
-                                  height: 400,
-                                  decoration: BoxDecoration(
-                                    color:
-                                        Theme.of(context).colorScheme.surface,
-                                    boxShadow: [
-                                      BoxShadow(
-                                        blurRadius: 2,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary,
-                                        offset: const Offset(
-                                          0,
-                                          2,
+                        return SingleChildScrollView(
+                          child: DefaultTabController(
+                            length: 3,
+                            child: Wrap(
+                              children: [
+                                Column(
+                                  mainAxisSize: MainAxisSize.max,
+                                  children: [
+                                    Align(
+                                      alignment:
+                                          const AlignmentDirectional(-1, 0),
+                                      child: Padding(
+                                        padding: const EdgeInsetsDirectional
+                                            .fromSTEB(16, 5, 0, 0),
+                                        child: Text(
+                                          'Events:',
+                                          textAlign: TextAlign.start,
+                                          style: TextStyle(
+                                            fontSize: 32,
+                                            fontWeight: FontWeight.bold,
+                                            color: Theme.of(context)
+                                                .colorScheme
+                                                .onSurface,
+                                          ),
                                         ),
-                                      )
-                                    ],
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
-                                  child: Padding(
-                                    padding:
-                                        const EdgeInsetsDirectional.fromSTEB(
-                                            0, 16, 0, 0),
-                                    child: Column(
-                                      mainAxisSize: MainAxisSize.max,
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.start,
-                                      children: [
-                                        Expanded(
-                                          child: Column(
-
-                                            children: [
-                                              Align(
-                                                alignment:
-                                                    const Alignment(-1, 0),
-                                                child: ButtonsTabBar(
-                                                  labelStyle: TextStyle(
-                                                    fontFamily: 'Inter',
-                                                    color: Theme.of(context)
-                                                        .colorScheme
-                                                        .secondary,
-                                                    fontSize: 16,
-                                                    letterSpacing: 0,
-                                                    fontWeight: FontWeight.w500,
-                                                  ),
-                                                  unselectedLabelStyle:
-                                                      TextStyle(
-                                                          color:
-                                                              Theme.of(context)
-                                                                  .colorScheme
-                                                                  .secondary),
-                                                  unselectedBackgroundColor:
-                                                      Theme.of(context)
-                                                          .colorScheme
-                                                          .surface,
-                                                  borderColor: Theme.of(context)
-                                                      .colorScheme
-                                                      .primary,
-                                                  unselectedBorderColor:
-                                                      Theme.of(context)
-                                                          .colorScheme
-                                                          .secondary,
-                                                  borderWidth: 2,
-                                                  elevation: 0,
-                                                  backgroundColor:
-                                                      Theme.of(context)
-                                                          .colorScheme
-                                                          .surface,
-                                                  tabs: const [
-                                                    Tab(
-                                                      text: 'All',
-                                                    ),
-                                                    Tab(
-                                                      text: 'Subscribed',
-                                                    ),
-                                                    Tab(
-                                                      text: 'My events',
-                                                    ),
-                                                  ],
-                                                  onTap: (i) async {
-                                                    [
-                                                      () async {},
-                                                      () async {},
-                                                      () async {}
-                                                    ][i]();
-                                                  },
-                                                ),
+                                      ),
+                                    ),
+                                    Padding(
+                                      padding:
+                                          const EdgeInsetsDirectional.fromSTEB(
+                                              0, 12, 0, 0),
+                                      child: SizedBox(
+                                        width: double.infinity,
+                                        height: 150,
+                                        child: CarouselSlider.builder(
+                                          itemCount: joinedEvents?.length,
+                                          carouselController:
+                                              CarouselController(),
+                                          options: CarouselOptions(
+                                            initialPage: 0,
+                                            viewportFraction: 0.5,
+                                            disableCenter: true,
+                                            enlargeCenterPage: true,
+                                            enlargeFactor: 0.25,
+                                            enableInfiniteScroll: false,
+                                            scrollDirection: Axis.horizontal,
+                                            autoPlay: false,
+                                          ),
+                                          itemBuilder:
+                                              (context, index, realIndex) {
+                                            Event i = joinedEvents![index];
+                                            return UpcomingEventCardWidget(
+                                                e: i);
+                                          },
+                                        ),
+                                      ),
+                                    ),
+                                    Padding(
+                                      padding: const EdgeInsets.all(16),
+                                      child: Container(
+                                        width: 430,
+                                        height: 400,
+                                        decoration: BoxDecoration(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .surface,
+                                          boxShadow: [
+                                            BoxShadow(
+                                              blurRadius: 2,
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .secondary,
+                                              offset: const Offset(
+                                                0,
+                                                2,
                                               ),
+                                            )
+                                          ],
+                                          borderRadius:
+                                              BorderRadius.circular(12),
+                                        ),
+                                        child: Padding(
+                                          padding: const EdgeInsetsDirectional
+                                              .fromSTEB(0, 16, 0, 0),
+                                          child: Column(
+                                            mainAxisSize: MainAxisSize.max,
+                                            crossAxisAlignment:
+                                                CrossAxisAlignment.start,
+                                            children: [
                                               Expanded(
-                                                child: TabBarView(
-                                                  physics:
-                                                      const NeverScrollableScrollPhysics(),
+                                                child: Column(
                                                   children: [
-                                                    ClipRRect(
-                                                      borderRadius:
-                                                          const BorderRadius
-                                                              .only(
-                                                        bottomLeft:
-                                                            Radius.circular(12),
-                                                        bottomRight:
-                                                            Radius.circular(12),
-                                                        topLeft:
-                                                            Radius.circular(0),
-                                                        topRight:
-                                                            Radius.circular(0),
-                                                      ),
-                                                      child: Container(
-                                                        width: 100,
-                                                        height: 100,
-                                                        decoration:
-                                                            BoxDecoration(
+                                                    Align(
+                                                      alignment:
+                                                          const Alignment(
+                                                              -1, 0),
+                                                      child: ButtonsTabBar(
+                                                        labelStyle: TextStyle(
+                                                          fontFamily: 'Inter',
                                                           color:
                                                               Theme.of(context)
                                                                   .colorScheme
-                                                                  .surface,
-                                                          borderRadius:
-                                                              const BorderRadius
-                                                                  .only(
-                                                            bottomLeft:
-                                                                Radius.circular(
-                                                                    12),
-                                                            bottomRight:
-                                                                Radius.circular(
-                                                                    12),
-                                                            topLeft:
-                                                                Radius.circular(
-                                                                    0),
-                                                            topRight:
-                                                                Radius.circular(
-                                                                    0),
+                                                                  .secondary,
+                                                          fontSize: 16,
+                                                          letterSpacing: 0,
+                                                          fontWeight:
+                                                              FontWeight.w500,
+                                                        ),
+                                                        unselectedLabelStyle:
+                                                            TextStyle(
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary),
+                                                        unselectedBackgroundColor:
+                                                            Theme.of(context)
+                                                                .colorScheme
+                                                                .surface,
+                                                        borderColor:
+                                                            Theme.of(context)
+                                                                .colorScheme
+                                                                .primary,
+                                                        unselectedBorderColor:
+                                                            Theme.of(context)
+                                                                .colorScheme
+                                                                .secondary,
+                                                        borderWidth: 2,
+                                                        elevation: 0,
+                                                        backgroundColor:
+                                                            Theme.of(context)
+                                                                .colorScheme
+                                                                .surface,
+                                                        tabs: const [
+                                                          Tab(
+                                                            text: 'All',
                                                           ),
-                                                        ),
-                                                        child:
-                                                        ListView.separated(
-                                                          itemCount:
-                                                          allEvents!.length,
-                                                          padding:
-                                                          EdgeInsets.zero,
-                                                          scrollDirection:
-                                                          Axis.vertical,
-                                                          itemBuilder:
-                                                              (context, index) {
-                                                            Event i =
-                                                            allEvents![
-                                                            index];
-                                                            return EventCardWidget(
-                                                                e: i);
-                                                          },
-                                                          separatorBuilder:
-                                                              (context,
-                                                              index) =>
-                                                          const SizedBox(
-                                                              height:
-                                                              10),
-                                                        ),
+                                                          Tab(
+                                                            text: 'Subscribed',
+                                                          ),
+                                                          Tab(
+                                                            text: 'My events',
+                                                          ),
+                                                        ],
+                                                        onTap: (i) async {
+                                                          [
+                                                            () async {},
+                                                            () async {},
+                                                            () async {}
+                                                          ][i]();
+                                                        },
                                                       ),
                                                     ),
-                                                    ClipRRect(
-                                                      borderRadius:
-                                                          const BorderRadius
-                                                              .only(
-                                                        bottomLeft:
-                                                            Radius.circular(12),
-                                                        bottomRight:
-                                                            Radius.circular(12),
-                                                        topLeft:
-                                                            Radius.circular(0),
-                                                        topRight:
-                                                            Radius.circular(0),
-                                                      ),
-                                                      child: Container(
-                                                        width: 100,
-                                                        height: 100,
-                                                        decoration:
-                                                            BoxDecoration(
-                                                          color:
-                                                              Theme.of(context)
-                                                                  .colorScheme
-                                                                  .surface,
-                                                          borderRadius:
-                                                              const BorderRadius
-                                                                  .only(
-                                                            bottomLeft:
-                                                                Radius.circular(
-                                                                    12),
-                                                            bottomRight:
-                                                                Radius.circular(
-                                                                    12),
-                                                            topLeft:
-                                                                Radius.circular(
-                                                                    0),
-                                                            topRight:
-                                                                Radius.circular(
-                                                                    0),
+                                                    Expanded(
+                                                      child: TabBarView(
+                                                        physics:
+                                                            const NeverScrollableScrollPhysics(),
+                                                        children: [
+                                                          ClipRRect(
+                                                            borderRadius:
+                                                                const BorderRadius
+                                                                    .only(
+                                                              bottomLeft: Radius
+                                                                  .circular(12),
+                                                              bottomRight:
+                                                                  Radius
+                                                                      .circular(
+                                                                          12),
+                                                              topLeft: Radius
+                                                                  .circular(0),
+                                                              topRight: Radius
+                                                                  .circular(0),
+                                                            ),
+                                                            child: Container(
+                                                              width: 100,
+                                                              height: 100,
+                                                              decoration:
+                                                                  BoxDecoration(
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .surface,
+                                                                borderRadius:
+                                                                    const BorderRadius
+                                                                        .only(
+                                                                  bottomLeft: Radius
+                                                                      .circular(
+                                                                          12),
+                                                                  bottomRight: Radius
+                                                                      .circular(
+                                                                          12),
+                                                                  topLeft: Radius
+                                                                      .circular(
+                                                                          0),
+                                                                  topRight: Radius
+                                                                      .circular(
+                                                                          0),
+                                                                ),
+                                                              ),
+                                                              child: ListView
+                                                                  .separated(
+                                                                itemCount:
+                                                                    allEvents!
+                                                                        .length,
+                                                                padding:
+                                                                    EdgeInsets
+                                                                        .zero,
+                                                                scrollDirection:
+                                                                    Axis.vertical,
+                                                                itemBuilder:
+                                                                    (context,
+                                                                        index) {
+                                                                  Event i =
+                                                                      allEvents![
+                                                                          index];
+                                                                  return EventCardWidget(
+                                                                      e: i);
+                                                                },
+                                                                separatorBuilder: (context,
+                                                                        index) =>
+                                                                    const SizedBox(
+                                                                        height:
+                                                                            10),
+                                                              ),
+                                                            ),
                                                           ),
-                                                        ),
-                                                        child:
-                                                        ListView.separated(
-                                                          itemCount:
-                                                          subscribedEvents!.length,
-                                                          padding:
-                                                          EdgeInsets.zero,
-                                                          scrollDirection:
-                                                          Axis.vertical,
-                                                          itemBuilder:
-                                                              (context, index) {
-                                                            Event i =
-                                                            subscribedEvents![
-                                                            index];
-                                                            return EventCardWidget(
-                                                                e: i);
-                                                          },
-                                                          separatorBuilder:
-                                                              (context,
-                                                              index) =>
-                                                          const SizedBox(
-                                                              height:
-                                                              10),
-                                                        ),
+                                                          ClipRRect(
+                                                            borderRadius:
+                                                                const BorderRadius
+                                                                    .only(
+                                                              bottomLeft: Radius
+                                                                  .circular(12),
+                                                              bottomRight:
+                                                                  Radius
+                                                                      .circular(
+                                                                          12),
+                                                              topLeft: Radius
+                                                                  .circular(0),
+                                                              topRight: Radius
+                                                                  .circular(0),
+                                                            ),
+                                                            child: Container(
+                                                              width: 100,
+                                                              height: 100,
+                                                              decoration:
+                                                                  BoxDecoration(
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .surface,
+                                                                borderRadius:
+                                                                    const BorderRadius
+                                                                        .only(
+                                                                  bottomLeft: Radius
+                                                                      .circular(
+                                                                          12),
+                                                                  bottomRight: Radius
+                                                                      .circular(
+                                                                          12),
+                                                                  topLeft: Radius
+                                                                      .circular(
+                                                                          0),
+                                                                  topRight: Radius
+                                                                      .circular(
+                                                                          0),
+                                                                ),
+                                                              ),
+                                                              child: ListView
+                                                                  .separated(
+                                                                itemCount:
+                                                                    subscribedEvents!
+                                                                        .length,
+                                                                padding:
+                                                                    EdgeInsets
+                                                                        .zero,
+                                                                scrollDirection:
+                                                                    Axis.vertical,
+                                                                itemBuilder:
+                                                                    (context,
+                                                                        index) {
+                                                                  Event i =
+                                                                      subscribedEvents![
+                                                                          index];
+                                                                  return EventCardWidget(
+                                                                      e: i);
+                                                                },
+                                                                separatorBuilder: (context,
+                                                                        index) =>
+                                                                    const SizedBox(
+                                                                        height:
+                                                                            10),
+                                                              ),
+                                                            ),
+                                                          ),
+                                                          ClipRRect(
+                                                            borderRadius:
+                                                                const BorderRadius
+                                                                    .only(
+                                                              bottomLeft: Radius
+                                                                  .circular(12),
+                                                              bottomRight:
+                                                                  Radius
+                                                                      .circular(
+                                                                          12),
+                                                              topLeft: Radius
+                                                                  .circular(0),
+                                                              topRight: Radius
+                                                                  .circular(0),
+                                                            ),
+                                                            child: Container(
+                                                              width: 100,
+                                                              height: 100,
+                                                              decoration:
+                                                                  BoxDecoration(
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .surface,
+                                                                borderRadius:
+                                                                    const BorderRadius
+                                                                        .only(
+                                                                  bottomLeft: Radius
+                                                                      .circular(
+                                                                          12),
+                                                                  bottomRight: Radius
+                                                                      .circular(
+                                                                          12),
+                                                                  topLeft: Radius
+                                                                      .circular(
+                                                                          0),
+                                                                  topRight: Radius
+                                                                      .circular(
+                                                                          0),
+                                                                ),
+                                                              ),
+                                                              child: ListView
+                                                                  .separated(
+                                                                itemCount:
+                                                                    myEvents!
+                                                                        .length,
+                                                                padding:
+                                                                    EdgeInsets
+                                                                        .zero,
+                                                                scrollDirection:
+                                                                    Axis.vertical,
+                                                                itemBuilder:
+                                                                    (context,
+                                                                        index) {
+                                                                  Event i =
+                                                                      myEvents![
+                                                                          index];
+                                                                  return EventCardWidget(
+                                                                      e: i);
+                                                                },
+                                                                separatorBuilder: (context,
+                                                                        index) =>
+                                                                    const SizedBox(
+                                                                        height:
+                                                                            10),
+                                                              ),
+                                                            ),
+                                                          ),
+                                                        ],
                                                       ),
                                                     ),
-                                                    ClipRRect(
-                                                      borderRadius:
-                                                          const BorderRadius
-                                                              .only(
-                                                        bottomLeft:
-                                                            Radius.circular(12),
-                                                        bottomRight:
-                                                            Radius.circular(12),
-                                                        topLeft:
-                                                            Radius.circular(0),
-                                                        topRight:
-                                                            Radius.circular(0),
-                                                      ),
-                                                      child: Container(
-                                                        width: 100,
-                                                        height: 100,
-                                                        decoration:
-                                                            BoxDecoration(
-                                                          color:
-                                                              Theme.of(context)
-                                                                  .colorScheme
-                                                                  .surface,
-                                                          borderRadius:
-                                                              const BorderRadius
-                                                                  .only(
-                                                            bottomLeft:
-                                                                Radius.circular(
-                                                                    12),
-                                                            bottomRight:
-                                                                Radius.circular(
-                                                                    12),
-                                                            topLeft:
-                                                                Radius.circular(
-                                                                    0),
-                                                            topRight:
-                                                                Radius.circular(
-                                                                    0),
-                                                          ),
-                                                        ),
-                                                        child:
-                                                        ListView.separated(
-                                                          itemCount:
-                                                          myEvents!.length,
-                                                          padding:
-                                                          EdgeInsets.zero,
-                                                          scrollDirection:
-                                                          Axis.vertical,
-                                                          itemBuilder:
-                                                              (context, index) {
-                                                            Event i =
-                                                            myEvents![
-                                                            index];
-                                                            return EventCardWidget(
-                                                                e: i);
-                                                          },
-                                                          separatorBuilder:
-                                                              (context,
-                                                              index) =>
-                                                          const SizedBox(
-                                                              height:
-                                                              10),
-                                                        ),
-                                                        ),
-                                                      ),
                                                   ],
                                                 ),
                                               ),
                                             ],
                                           ),
                                         ),
-                                      ],
+                                      ),
                                     ),
-                                  ),
+                                  ],
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
-                          ],
-                          ),
-                        ),
                         );
                       }
                     }))));

--- a/lib/view/pages/feed/feed_page.dart
+++ b/lib/view/pages/feed/feed_page.dart
@@ -33,6 +33,7 @@ class _FeedPageState extends State<FeedPage> {
 
   ProfileService profileService = ProfileService();
   late TextEditingController usernamecontroller;
+  
 
   static final List<Widget> _pages = <Widget>[
     Center(
@@ -48,7 +49,7 @@ class _FeedPageState extends State<FeedPage> {
     super.initState();
     usernamecontroller = TextEditingController();
     WidgetsBinding.instance
-        .addPostFrameCallback((_) => _checkProfileAndShowDialog());
+        .addPostFrameCallback((_) => _checkProfileAndShowDialog());      
   }
 
   @override
@@ -334,7 +335,7 @@ class _FeedPageDisplay extends StatelessWidget {
               },
               icon: Icon(
                 Icons.message,
-                color: Theme.of(context).colorScheme.secondary,
+                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
           ),

--- a/lib/view/pages/messaging/chat_page.dart
+++ b/lib/view/pages/messaging/chat_page.dart
@@ -81,7 +81,6 @@ class _ChatPageState extends State<ChatPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.primary,
         title: Text(widget.profileName),
       ),
       body: Column(

--- a/lib/view/pages/messaging/chat_page.dart
+++ b/lib/view/pages/messaging/chat_page.dart
@@ -29,11 +29,14 @@ class _ChatPageState extends State<ChatPage> {
     super.initState();
     newFocusNode.addListener(() {
       if (newFocusNode.hasFocus) {
-        Future.delayed(const Duration(milliseconds: 500), () => scrollDownPage());
+        Future.delayed(
+            const Duration(milliseconds: 500), () => scrollDownPage());
       }
     });
-
-    Future.delayed(const Duration(milliseconds: 500),() => scrollDownPage(),);
+    Future.delayed(
+      const Duration(milliseconds: 500),
+      () => scrollDownPage(),
+    );
   }
 
   @override
@@ -140,7 +143,10 @@ class _ChatPageState extends State<ChatPage> {
     return Container(
       alignment: alignment,
       child: ChatBubble(
-          message: data["message_text"], isCurrentuser: isCurrentuser, time: data["timestamp"],),
+        message: data["message_text"],
+        isCurrentuser: isCurrentuser,
+        time: data["timestamp"],
+      ),
     );
   }
 
@@ -150,35 +156,33 @@ class _ChatPageState extends State<ChatPage> {
       child: Row(
         children: [
           Expanded(
-            child: TextFormField(
-              focusNode: newFocusNode,
-              controller: _textEditingController,
-              obscureText: false,
-              decoration: InputDecoration(
-                hintText: "Enter your message here",
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(5.0),
-                  borderSide: BorderSide(
-                    color: Theme.of(context).colorScheme.primary,
+            child: ValueListenableBuilder<TextEditingValue>(
+              valueListenable: _textEditingController,
+              builder: (context, value, child) {
+                return TextFormField(
+                  focusNode: newFocusNode,
+                  controller: _textEditingController,
+                  obscureText: false,
+                  decoration: InputDecoration(
+                    hintText: "Enter your message here",
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(30.0),
+                      borderSide: BorderSide(
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                    suffixIcon: value.text.isNotEmpty
+                        ? IconButton(
+                            onPressed: sendMessage,
+                            icon: Icon(
+                              Icons.send,
+                              color: Theme.of(context).colorScheme.primary,
+                            ),
+                          )
+                        : null,
                   ),
-                ),
-              ),
-            ),
-          ),
-          Container(
-            width: 50,
-            height: 50,
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.primary,
-              shape: BoxShape.circle,
-            ),
-            child: IconButton(
-              onPressed: sendMessage,
-              icon: const Icon(
-                Icons.arrow_forward_ios,
-                size: 35,
-              ),
+                );
+              },
             ),
           ),
         ],

--- a/lib/view/pages/messaging/chat_page.dart
+++ b/lib/view/pages/messaging/chat_page.dart
@@ -180,6 +180,9 @@ class _ChatPageState extends State<ChatPage> {
                           )
                         : null,
                   ),
+                  onFieldSubmitted: (value) {
+                    sendMessage();
+                  },
                 );
               },
             ),

--- a/lib/view/pages/messaging/messaging_page.dart
+++ b/lib/view/pages/messaging/messaging_page.dart
@@ -30,24 +30,20 @@ class _MessagingState extends State<Messaging> {
   Widget build(BuildContext context) {
     return Scaffold(
         key: scaffoldKey,
-        backgroundColor: Theme.of(context).colorScheme.surface,
         appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.primary,
-          automaticallyImplyLeading: true,
           leading: IconButton(
-            icon: Icon(Icons.arrow_back,
-                color: Theme.of(context).colorScheme.surface),
-            onPressed: () => Navigator.of(context).pop(),
-          ),
+          icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.secondary),
+          onPressed: () {
+            Navigator.pop(context);
+          },
+        ),
           title: Text(
             'My Messages',
             style: TextStyle(
-              fontFamily: 'Inter',
-              color: Theme.of(context).colorScheme.surface,
-              fontSize: 20,
-              letterSpacing: 0,
-              fontWeight: FontWeight.w900,
-            ),
+            fontSize: 32,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
           ),
           actions: const [],
           centerTitle: false,

--- a/lib/view/pages/messaging/messaging_page.dart
+++ b/lib/view/pages/messaging/messaging_page.dart
@@ -6,6 +6,7 @@ import 'package:gameonconnect/services/authentication_S/auth_service.dart';
 //import 'package:gameonconnect/model/profile_M/profile_model.dart';
 import 'package:gameonconnect/services/messaging_S/messaging_service.dart';
 import 'package:gameonconnect/services/profile_S/storage_service.dart';
+import 'package:gameonconnect/view/components/appbars/backbutton_appbar_component.dart';
 //import 'package:gameonconnect/services/profile_S/profile_service.dart';
 //import 'package:cached_network_image/cached_network_image.dart';
 import 'package:gameonconnect/view/components/card/custom_toast_card.dart';
@@ -30,24 +31,13 @@ class _MessagingState extends State<Messaging> {
   Widget build(BuildContext context) {
     return Scaffold(
         key: scaffoldKey,
-        appBar: AppBar(
-          leading: IconButton(
-          icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.secondary),
-          onPressed: () {
+        appBar: BackButtonAppBar(
+          title: 'Messages',
+          onBackButtonPressed: () {
             Navigator.pop(context);
           },
-        ),
-          title: Text(
-            'My Messages',
-            style: TextStyle(
-            fontSize: 32,
-            fontWeight: FontWeight.bold,
-            color: Theme.of(context).colorScheme.onSurface,
-          ),
-          ),
-          actions: const [],
-          centerTitle: false,
-          elevation: 0,
+          iconkey: const Key('Back_button_key'),
+          textkey: const Key('messages_text'),
         ),
         body: _buildUserList());
   }

--- a/lib/view/pages/settings/customize_page.dart
+++ b/lib/view/pages/settings/customize_page.dart
@@ -11,6 +11,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:gameonconnect/services/profile_S/storage_service.dart';
+import 'package:gameonconnect/view/components/appbars/backbutton_appbar_component.dart';
 import 'package:gameonconnect/view/theme/theme_provider.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
@@ -334,21 +335,14 @@ class CustomizeProfilePageObject extends State<CustomizeProfilePage> {
 
   Widget _buildContent(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon: const Icon(Icons.keyboard_backspace),
-          onPressed: () {
-            Navigator.of(context).pop();
+      appBar: BackButtonAppBar(
+          title: 'Customize Profile',
+          onBackButtonPressed: () {
+            Navigator.pop(context);
           },
+          iconkey: const Key('Back_button_key'),
+          textkey: const Key('customize_profile_text'),
         ),
-        title: const Text(
-            'Customize Profile',
-            style: TextStyle(
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-      ),
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [

--- a/lib/view/pages/settings/edit_profile_page.dart
+++ b/lib/view/pages/settings/edit_profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:gameonconnect/view/components/appbars/backbutton_appbar_component.dart';
 import 'dart:io';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 
@@ -11,21 +12,14 @@ class EditProfilePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: IconButton(
-          icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.secondary),
-          onPressed: () {
+      appBar: BackButtonAppBar(
+          title: 'Edit Profile',
+          onBackButtonPressed: () {
             Navigator.pop(context);
           },
+          iconkey: const Key('Back_button_key'),
+          textkey: const Key('edit_profile_text'),
         ),
-        title: const Text(
-            'Edit Profile',
-            style: TextStyle(
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-      ),
       body: const EditProfileForm(),
     );
   }

--- a/lib/view/pages/settings/getting_started_page.dart
+++ b/lib/view/pages/settings/getting_started_page.dart
@@ -12,29 +12,23 @@ class GettingStarted extends StatelessWidget {
         appBar: AppBar(
           automaticallyImplyLeading: false,
           leading: IconButton(
-            icon:  Icon(
-              key: Key('back_button'),
-              Icons.arrow_back_rounded,
-              color: Theme.of(context).colorScheme.surface,
-              size: 30,
-            ),
-            onPressed: () async {
+            icon: Icon(
+                key: Key('back_button'),
+                Icons.arrow_back,
+                color: Theme.of(context).colorScheme.secondary),
+            onPressed: () {
               Navigator.pop(context);
             },
           ),
-          title:  Text(
-            key : Key('getting_started'),
+          title: Text(
+            key: Key('getting_started'),
             'Getting Started',
             style: TextStyle(
-              fontFamily: 'Inter',
-              color: Theme.of(context).colorScheme.surface,
-              fontSize: 30,
-              letterSpacing: 0,
+              fontSize: 32,
+              fontWeight: FontWeight.bold,
+              color: Theme.of(context).colorScheme.onSurface,
             ),
           ),
-          backgroundColor: Theme.of(context).colorScheme.primary,
-          centerTitle: true,
-          elevation: 2,
         ),
         body: SafeArea(
             top: true,
@@ -73,7 +67,7 @@ class GettingStarted extends StatelessWidget {
                           mainAxisSize: MainAxisSize.max,
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                             Padding(
+                            Padding(
                               padding:
                                   EdgeInsetsDirectional.fromSTEB(12, 0, 12, 12),
                               child: Row(
@@ -86,18 +80,21 @@ class GettingStarted extends StatelessWidget {
                                       'Friends',
                                       style: TextStyle(
                                         fontFamily: 'Inter',
-                                        color: Theme.of(context).colorScheme.secondary,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
                                         fontSize: 20,
                                         letterSpacing: 0,
                                         fontWeight: FontWeight.w500,
                                       ),
-                                      overflow: TextOverflow.ellipsis, //handles possible overflow
+                                      overflow: TextOverflow
+                                          .ellipsis, //handles possible overflow
                                     ),
                                   ),
                                 ],
                               ),
                             ),
-                             Divider(
+                            Divider(
                               height: 1,
                               thickness: 1,
                               color: Theme.of(context).colorScheme.surface,
@@ -112,14 +109,16 @@ class GettingStarted extends StatelessWidget {
                                     padding: EdgeInsetsDirectional.fromSTEB(
                                         0, 0, 0, 1),
                                     child: Container(
-                                      decoration:  BoxDecoration(
-                                        color: Theme.of(context).colorScheme.surface,
+                                      decoration: BoxDecoration(
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .surface,
                                       ),
                                       child: SizedBox(
                                         width: double.infinity,
                                         child: ExpansionTile(
                                           key: Key('how_to_friends_List_tile'),
-                                          title:  Padding(
+                                          title: Padding(
                                             padding:
                                                 EdgeInsetsDirectional.fromSTEB(
                                                     12, 8, 12, 8),
@@ -134,11 +133,15 @@ class GettingStarted extends StatelessWidget {
                                                     'How to search for friends',
                                                     style: TextStyle(
                                                       fontFamily: 'Inter',
-                                                      color: Theme.of(context).colorScheme.secondary,
+                                                      color: Theme.of(context)
+                                                          .colorScheme
+                                                          .secondary,
                                                       letterSpacing: 0,
-                                                      fontWeight: FontWeight.w500,
+                                                      fontWeight:
+                                                          FontWeight.w500,
                                                     ),
-                                                    overflow: TextOverflow.ellipsis, //handles possible overflow
+                                                    overflow: TextOverflow
+                                                        .ellipsis, //handles possible overflow
                                                   ),
                                                 ),
                                               ],
@@ -150,21 +153,23 @@ class GettingStarted extends StatelessWidget {
                                               children: [
                                                 Container(
                                                   width: double.infinity,
-                                                  decoration:
-                                                       BoxDecoration(
-                                                    color: Theme.of(context).colorScheme.surface,
+                                                  decoration: BoxDecoration(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .surface,
                                                   ),
                                                 ),
                                                 Container(
                                                   width: double.infinity,
-                                                  decoration:
-                                                       BoxDecoration(
-                                                    color: Theme.of(context).colorScheme.surface,
+                                                  decoration: BoxDecoration(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .surface,
                                                   ),
                                                 ),
                                                 SizedBox(
                                                   width: double.infinity,
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -183,7 +188,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_searching_friends'),
+                                                              key: Key(
+                                                                  'key_searching_friends'),
                                                               'Navigate to the '
                                                               'search tab. '
                                                               'Select the Friends'
@@ -193,7 +199,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 letterSpacing:
                                                                     0,
                                                                 fontWeight:
@@ -216,16 +225,22 @@ class GettingStarted extends StatelessWidget {
                                                     decoration: BoxDecoration(),
                                                   ),
                                                 ),
-
                                                 SizedBox(
                                                   width: double.infinity,
                                                   child: Padding(
-                                                    padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                    child: TutorialVideo(videoPath: 'assets/videos/Connections_1.mp4'),
+                                                    padding:
+                                                        EdgeInsetsDirectional
+                                                            .fromSTEB(
+                                                                12, 8, 12, 8),
+                                                    child: TutorialVideo(
+                                                        videoPath:
+                                                            'assets/videos/Connections_1.mp4'),
                                                   ),
                                                 ),
                                                 Padding(
-                                                  padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                  padding:
+                                                      const EdgeInsetsDirectional
+                                                          .fromSTEB(0, 4, 0, 0),
                                                   child: Container(
                                                     width: double.infinity,
                                                     decoration: BoxDecoration(),
@@ -243,7 +258,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('how_to_add_friends'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -257,11 +272,14 @@ class GettingStarted extends StatelessWidget {
                                                   'How to add friends',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
-                                                  overflow: TextOverflow.ellipsis, //handles possible overflow
+                                                  overflow: TextOverflow
+                                                      .ellipsis, //handles possible overflow
                                                 ),
                                               ),
                                             ],
@@ -273,20 +291,26 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Padding(
@@ -295,11 +319,12 @@ class GettingStarted extends StatelessWidget {
                                                         .fromSTEB(0, 0, 0, 4),
                                                 child: Container(
                                                   width: double.infinity,
-                                                  decoration:
-                                                       BoxDecoration(
-                                                    color: Theme.of(context).colorScheme.surface,
+                                                  decoration: BoxDecoration(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .surface,
                                                   ),
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -318,7 +343,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_adding_friends'),
+                                                              key: Key(
+                                                                  'key_adding_friends'),
                                                               'To add friends,'
                                                               ' navigate to the'
                                                               ' search page , search'
@@ -331,7 +357,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 letterSpacing:
                                                                     0,
                                                                 fontWeight:
@@ -349,12 +378,17 @@ class GettingStarted extends StatelessWidget {
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/Connections_2.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/Connections_2.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),
@@ -371,7 +405,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('Accepting_friends'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -385,7 +419,9 @@ class GettingStarted extends StatelessWidget {
                                                   'Accepting/rejecting friend requests',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
@@ -400,20 +436,26 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Padding(
@@ -422,7 +464,7 @@ class GettingStarted extends StatelessWidget {
                                                         .fromSTEB(0, 0, 0, 4),
                                                 child: SizedBox(
                                                   width: double.infinity,
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -441,7 +483,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_friend_requests'),
+                                                              key: Key(
+                                                                  'key_friend_requests'),
                                                               'To accept or reject'
                                                               ' friend requests, '
                                                               'navigate to your'
@@ -452,7 +495,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 fontSize: 14,
                                                                 letterSpacing:
                                                                     0,
@@ -471,12 +517,17 @@ class GettingStarted extends StatelessWidget {
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/Connections_3.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/Connections_3.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),
@@ -488,7 +539,6 @@ class GettingStarted extends StatelessWidget {
                                       ),
                                     ),
                                   ),
-
                                 ]),
                           ],
                         ),
@@ -514,7 +564,7 @@ class GettingStarted extends StatelessWidget {
                         ],
                         borderRadius: BorderRadius.circular(8),
                         border: Border.all(
-                          color:  Theme.of(context).colorScheme.surface,
+                          color: Theme.of(context).colorScheme.surface,
                           width: 2,
                         ),
                       ),
@@ -525,7 +575,7 @@ class GettingStarted extends StatelessWidget {
                           mainAxisSize: MainAxisSize.max,
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                             Padding(
+                            Padding(
                               padding:
                                   EdgeInsetsDirectional.fromSTEB(12, 0, 12, 12),
                               child: Row(
@@ -537,7 +587,9 @@ class GettingStarted extends StatelessWidget {
                                     'Game Library',
                                     style: TextStyle(
                                       fontFamily: 'Inter',
-                                      color: Theme.of(context).colorScheme.secondary,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .secondary,
                                       fontSize: 20,
                                       letterSpacing: 0,
                                       fontWeight: FontWeight.w500,
@@ -546,7 +598,7 @@ class GettingStarted extends StatelessWidget {
                                 ],
                               ),
                             ),
-                             Divider(
+                            Divider(
                               height: 1,
                               thickness: 1,
                               color: Theme.of(context).colorScheme.surface,
@@ -561,12 +613,15 @@ class GettingStarted extends StatelessWidget {
                                   padding: EdgeInsetsDirectional.fromSTEB(
                                       0, 0, 0, 1),
                                   child: Container(
-                                    decoration:  BoxDecoration(
-                                      color: Theme.of(context).colorScheme.surface,
+                                    decoration: BoxDecoration(
+                                      color:
+                                          Theme.of(context).colorScheme.surface,
                                       boxShadow: [
                                         BoxShadow(
                                           blurRadius: 0,
-                                          color: Theme.of(context).colorScheme.surface,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .surface,
                                           offset: Offset(
                                             0,
                                             1,
@@ -578,7 +633,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('how_search_games'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -592,7 +647,9 @@ class GettingStarted extends StatelessWidget {
                                                   'How to search for games',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
@@ -607,19 +664,23 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               SizedBox(
                                                 width: double.infinity,
-                                                child:  Padding(
+                                                child: Padding(
                                                   padding: EdgeInsetsDirectional
                                                       .fromSTEB(12, 8, 12, 8),
                                                   child: Row(
@@ -633,7 +694,8 @@ class GettingStarted extends StatelessWidget {
                                                                   .fromSTEB(12,
                                                                       0, 0, 0),
                                                           child: Text(
-                                                            key: Key('key_navigate_search_games'),
+                                                            key: Key(
+                                                                'key_navigate_search_games'),
                                                             'Navigate to the'
                                                             ' search tab.'
                                                             ' Select the Games'
@@ -642,7 +704,10 @@ class GettingStarted extends StatelessWidget {
                                                             style: TextStyle(
                                                               fontFamily:
                                                                   'Inter',
-                                                              color: Theme.of(context).colorScheme.secondary,
+                                                              color: Theme.of(
+                                                                      context)
+                                                                  .colorScheme
+                                                                  .secondary,
                                                               fontSize: 14,
                                                               letterSpacing: 0,
                                                               fontWeight:
@@ -665,16 +730,20 @@ class GettingStarted extends StatelessWidget {
                                                   decoration: BoxDecoration(),
                                                 ),
                                               ),
-
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/GameLibrary_1.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/GameLibrary_1.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),
@@ -691,7 +760,7 @@ class GettingStarted extends StatelessWidget {
                                   width: double.infinity,
                                   child: ExpansionTile(
                                     key: Key('how_sort_games'),
-                                    title:  Padding(
+                                    title: Padding(
                                       padding: EdgeInsetsDirectional.fromSTEB(
                                           12, 8, 12, 8),
                                       child: Row(
@@ -704,7 +773,9 @@ class GettingStarted extends StatelessWidget {
                                               'How to sort the Game Library',
                                               style: TextStyle(
                                                 fontFamily: 'Inter',
-                                                color: Theme.of(context).colorScheme.secondary,
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .secondary,
                                                 letterSpacing: 0,
                                                 fontWeight: FontWeight.w500,
                                               ),
@@ -719,20 +790,26 @@ class GettingStarted extends StatelessWidget {
                                         children: [
                                           Container(
                                             width: double.infinity,
-                                            decoration:  BoxDecoration(
-                                              color: Theme.of(context).colorScheme.surface,
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ),
                                           ),
                                           Container(
                                             width: double.infinity,
-                                            decoration:  BoxDecoration(
-                                              color: Theme.of(context).colorScheme.surface,
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ),
                                           ),
                                           Container(
                                             width: double.infinity,
-                                            decoration:  BoxDecoration(
-                                              color: Theme.of(context).colorScheme.surface,
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ),
                                           ),
                                           Padding(
@@ -740,8 +817,10 @@ class GettingStarted extends StatelessWidget {
                                                 .fromSTEB(0, 0, 0, 4),
                                             child: Container(
                                               width: double.infinity,
-                                              decoration:  BoxDecoration(
-                                                color: Theme.of(context).colorScheme.surface,
+                                              decoration: BoxDecoration(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .surface,
                                               ),
                                               child: Padding(
                                                 padding: EdgeInsetsDirectional
@@ -757,7 +836,8 @@ class GettingStarted extends StatelessWidget {
                                                                 .fromSTEB(12, 0,
                                                                     0, 0),
                                                         child: Text(
-                                                          key: Key('key_navigate_sort_games'),
+                                                          key: Key(
+                                                              'key_navigate_sort_games'),
                                                           'Navigate to the search'
                                                           ' tab. Click on the'
                                                           ' sort button and '
@@ -767,7 +847,10 @@ class GettingStarted extends StatelessWidget {
                                                           ' Library',
                                                           style: TextStyle(
                                                             fontFamily: 'Inter',
-                                                            color: Theme.of(context).colorScheme.secondary,
+                                                            color: Theme.of(
+                                                                    context)
+                                                                .colorScheme
+                                                                .secondary,
                                                             fontSize: 14,
                                                             letterSpacing: 0,
                                                             fontWeight:
@@ -784,12 +867,16 @@ class GettingStarted extends StatelessWidget {
                                           SizedBox(
                                             width: double.infinity,
                                             child: Padding(
-                                              padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                              child: TutorialVideo(videoPath: 'assets/videos/GameLibrary_2.mp4'),
+                                              padding: EdgeInsetsDirectional
+                                                  .fromSTEB(12, 8, 12, 8),
+                                              child: TutorialVideo(
+                                                  videoPath:
+                                                      'assets/videos/GameLibrary_2.mp4'),
                                             ),
                                           ),
                                           Padding(
-                                            padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                            padding: const EdgeInsetsDirectional
+                                                .fromSTEB(0, 4, 0, 0),
                                             child: Container(
                                               width: double.infinity,
                                               decoration: BoxDecoration(),
@@ -804,7 +891,7 @@ class GettingStarted extends StatelessWidget {
                                   width: double.infinity,
                                   child: ExpansionTile(
                                     key: Key('filter_games'),
-                                    title:  Padding(
+                                    title: Padding(
                                       padding: EdgeInsetsDirectional.fromSTEB(
                                           12, 8, 12, 8),
                                       child: Row(
@@ -817,7 +904,9 @@ class GettingStarted extends StatelessWidget {
                                               'How to filter the Game Library',
                                               style: TextStyle(
                                                 fontFamily: 'Inter',
-                                                color: Theme.of(context).colorScheme.secondary,
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .secondary,
                                                 letterSpacing: 0,
                                                 fontWeight: FontWeight.w500,
                                               ),
@@ -832,20 +921,26 @@ class GettingStarted extends StatelessWidget {
                                         children: [
                                           Container(
                                             width: double.infinity,
-                                            decoration:  BoxDecoration(
-                                              color:Theme.of(context).colorScheme.surface,
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ),
                                           ),
                                           Container(
                                             width: double.infinity,
-                                            decoration:  BoxDecoration(
-                                              color: Theme.of(context).colorScheme.surface,
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ),
                                           ),
                                           Container(
                                             width: double.infinity,
-                                            decoration:  BoxDecoration(
-                                              color: Theme.of(context).colorScheme.surface,
+                                            decoration: BoxDecoration(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .surface,
                                             ),
                                           ),
                                           Padding(
@@ -853,7 +948,7 @@ class GettingStarted extends StatelessWidget {
                                                 .fromSTEB(0, 0, 0, 4),
                                             child: SizedBox(
                                               width: double.infinity,
-                                              child:  Padding(
+                                              child: Padding(
                                                 padding: EdgeInsetsDirectional
                                                     .fromSTEB(12, 8, 12, 8),
                                                 child: Row(
@@ -867,7 +962,8 @@ class GettingStarted extends StatelessWidget {
                                                                 .fromSTEB(12, 0,
                                                                     0, 0),
                                                         child: Text(
-                                                          key: Key('key_how_to_filter_games'),
+                                                          key: Key(
+                                                              'key_how_to_filter_games'),
                                                           'Navigate to the search'
                                                           ' tab. Click on the'
                                                           ' filter button and '
@@ -876,7 +972,10 @@ class GettingStarted extends StatelessWidget {
                                                           'to the Game Library.',
                                                           style: TextStyle(
                                                             fontFamily: 'Inter',
-                                                            color: Theme.of(context).colorScheme.secondary,
+                                                            color: Theme.of(
+                                                                    context)
+                                                                .colorScheme
+                                                                .secondary,
                                                             fontSize: 14,
                                                             letterSpacing: 0,
                                                             fontWeight:
@@ -893,12 +992,16 @@ class GettingStarted extends StatelessWidget {
                                           SizedBox(
                                             width: double.infinity,
                                             child: Padding(
-                                              padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                              child: TutorialVideo(videoPath: 'assets/videos/GameLibrary_3.mp4'),
+                                              padding: EdgeInsetsDirectional
+                                                  .fromSTEB(12, 8, 12, 8),
+                                              child: TutorialVideo(
+                                                  videoPath:
+                                                      'assets/videos/GameLibrary_3.mp4'),
                                             ),
                                           ),
                                           Padding(
-                                            padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                            padding: const EdgeInsetsDirectional
+                                                .fromSTEB(0, 4, 0, 0),
                                             child: Container(
                                               width: double.infinity,
                                               decoration: BoxDecoration(),
@@ -949,7 +1052,7 @@ class GettingStarted extends StatelessWidget {
                               mainAxisSize: MainAxisSize.max,
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
-                                 Padding(
+                                Padding(
                                   padding: EdgeInsetsDirectional.fromSTEB(
                                       12, 0, 12, 12),
                                   child: Row(
@@ -961,7 +1064,9 @@ class GettingStarted extends StatelessWidget {
                                         'Game Information',
                                         style: TextStyle(
                                           fontFamily: 'Inter',
-                                          color: Theme.of(context).colorScheme.secondary,
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .secondary,
                                           fontSize: 20,
                                           letterSpacing: 0,
                                           fontWeight: FontWeight.w500,
@@ -970,7 +1075,7 @@ class GettingStarted extends StatelessWidget {
                                     ],
                                   ),
                                 ),
-                                 Divider(
+                                Divider(
                                   height: 1,
                                   thickness: 1,
                                   color: Theme.of(context).colorScheme.surface,
@@ -985,8 +1090,10 @@ class GettingStarted extends StatelessWidget {
                                           const EdgeInsetsDirectional.fromSTEB(
                                               0, 0, 0, 1),
                                       child: Container(
-                                        decoration:  BoxDecoration(
-                                          color: Theme.of(context).colorScheme.surface,
+                                        decoration: BoxDecoration(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .surface,
                                         ),
                                         child: SizedBox(
                                           width: double.infinity,
@@ -1000,14 +1107,15 @@ class GettingStarted extends StatelessWidget {
                                                 mainAxisAlignment:
                                                     MainAxisAlignment
                                                         .spaceBetween,
-                                                children:  [
+                                                children: [
                                                   Flexible(
                                                     child: Text(
                                                       'How to view more information about a game',
                                                       style: TextStyle(
                                                         fontFamily: 'Inter',
-                                                        color:
-                                                        Theme.of(context).colorScheme.secondary,
+                                                        color: Theme.of(context)
+                                                            .colorScheme
+                                                            .secondary,
                                                         letterSpacing: 0,
                                                         fontWeight:
                                                             FontWeight.w500,
@@ -1023,21 +1131,23 @@ class GettingStarted extends StatelessWidget {
                                                 children: [
                                                   Container(
                                                     width: double.infinity,
-                                                    decoration:
-                                                         BoxDecoration(
-                                                      color: Theme.of(context).colorScheme.surface,
+                                                    decoration: BoxDecoration(
+                                                      color: Theme.of(context)
+                                                          .colorScheme
+                                                          .surface,
                                                     ),
                                                   ),
                                                   Container(
                                                     width: double.infinity,
-                                                    decoration:
-                                                         BoxDecoration(
-                                                      color: Theme.of(context).colorScheme.surface,
+                                                    decoration: BoxDecoration(
+                                                      color: Theme.of(context)
+                                                          .colorScheme
+                                                          .surface,
                                                     ),
                                                   ),
                                                   SizedBox(
                                                     width: double.infinity,
-                                                    child:  Padding(
+                                                    child: Padding(
                                                       padding:
                                                           EdgeInsetsDirectional
                                                               .fromSTEB(
@@ -1056,7 +1166,8 @@ class GettingStarted extends StatelessWidget {
                                                                           0,
                                                                           0),
                                                               child: Text(
-                                                                key: Key('key_view_specific_game'),
+                                                                key: Key(
+                                                                    'key_view_specific_game'),
                                                                 'When you click'
                                                                 ' on a specific '
                                                                 'game in the Game'
@@ -1079,7 +1190,10 @@ class GettingStarted extends StatelessWidget {
                                                                     TextStyle(
                                                                   fontFamily:
                                                                       'Inter',
-                                                                  color: Theme.of(context).colorScheme.secondary,
+                                                                  color: Theme.of(
+                                                                          context)
+                                                                      .colorScheme
+                                                                      .secondary,
                                                                   fontSize: 14,
                                                                   letterSpacing:
                                                                       0,
@@ -1103,19 +1217,27 @@ class GettingStarted extends StatelessWidget {
                                                       width: double.infinity,
                                                     ),
                                                   ),
-                                                  
                                                   SizedBox(
                                                     width: double.infinity,
                                                     child: Padding(
-                                                      padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                      child: TutorialVideo(videoPath: 'assets/videos/GameInfo_1.mp4'),
+                                                      padding:
+                                                          EdgeInsetsDirectional
+                                                              .fromSTEB(
+                                                                  12, 8, 12, 8),
+                                                      child: TutorialVideo(
+                                                          videoPath:
+                                                              'assets/videos/GameInfo_1.mp4'),
                                                     ),
                                                   ),
                                                   Padding(
-                                                    padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                    padding:
+                                                        const EdgeInsetsDirectional
+                                                            .fromSTEB(
+                                                            0, 4, 0, 0),
                                                     child: Container(
                                                       width: double.infinity,
-                                                      decoration: BoxDecoration(),
+                                                      decoration:
+                                                          BoxDecoration(),
                                                     ),
                                                   ),
                                                 ],
@@ -1129,7 +1251,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('share_game_info'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -1143,7 +1265,9 @@ class GettingStarted extends StatelessWidget {
                                                   'How to share a game ',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
@@ -1158,20 +1282,26 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Padding(
@@ -1180,11 +1310,12 @@ class GettingStarted extends StatelessWidget {
                                                         .fromSTEB(0, 0, 0, 4),
                                                 child: Container(
                                                   width: double.infinity,
-                                                  decoration:
-                                                       BoxDecoration(
-                                                    color: Theme.of(context).colorScheme.surface,
+                                                  decoration: BoxDecoration(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .surface,
                                                   ),
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -1203,7 +1334,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_sharing_game_info'),
+                                                              key: Key(
+                                                                  'key_sharing_game_info'),
                                                               'Select a Game you'
                                                               ' want to share.'
                                                               'Click on the share'
@@ -1214,7 +1346,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 fontSize: 14,
                                                                 letterSpacing:
                                                                     0,
@@ -1233,12 +1368,17 @@ class GettingStarted extends StatelessWidget {
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/GameInfo_2.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/GameInfo_2.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),
@@ -1253,7 +1393,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('add_game_to_wishlist'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -1267,7 +1407,9 @@ class GettingStarted extends StatelessWidget {
                                                   'How do I add a game to my wishlist',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
@@ -1282,20 +1424,26 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Padding(
@@ -1304,7 +1452,7 @@ class GettingStarted extends StatelessWidget {
                                                         .fromSTEB(12, 8, 12, 8),
                                                 child: SizedBox(
                                                   width: double.infinity,
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -1323,7 +1471,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_add_to_wishlist'),
+                                                              key: Key(
+                                                                  'key_add_to_wishlist'),
                                                               'To add a game to '
                                                               'your wishlist,'
                                                               ' navigate to '
@@ -1338,7 +1487,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 fontSize: 14,
                                                                 letterSpacing:
                                                                     0,
@@ -1357,12 +1509,17 @@ class GettingStarted extends StatelessWidget {
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/GameInfo_3.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/GameInfo_3.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),
@@ -1377,7 +1534,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('add_to_currently_playing'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -1391,7 +1548,9 @@ class GettingStarted extends StatelessWidget {
                                                   'How to add a game to my Currently Playings list',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
@@ -1406,20 +1565,26 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Padding(
@@ -1428,7 +1593,7 @@ class GettingStarted extends StatelessWidget {
                                                         .fromSTEB(12, 8, 12, 8),
                                                 child: SizedBox(
                                                   width: double.infinity,
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -1447,7 +1612,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_navigate_to_currently_playing'),
+                                                              key: Key(
+                                                                  'key_navigate_to_currently_playing'),
                                                               'To add a game to'
                                                               ' your'
                                                               ' currently '
@@ -1470,7 +1636,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 fontSize: 14,
                                                                 letterSpacing:
                                                                     0,
@@ -1489,12 +1658,17 @@ class GettingStarted extends StatelessWidget {
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/GameInfo_4.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/GameInfo_4.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),
@@ -1509,7 +1683,7 @@ class GettingStarted extends StatelessWidget {
                                       width: double.infinity,
                                       child: ExpansionTile(
                                         key: Key('remove_from_wishlist'),
-                                        title:  Padding(
+                                        title: Padding(
                                           padding:
                                               EdgeInsetsDirectional.fromSTEB(
                                                   12, 8, 12, 8),
@@ -1523,7 +1697,9 @@ class GettingStarted extends StatelessWidget {
                                                   'How do I remove a game from my Wishlist',
                                                   style: TextStyle(
                                                     fontFamily: 'Inter',
-                                                    color: Theme.of(context).colorScheme.secondary,
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .secondary,
                                                     letterSpacing: 0,
                                                     fontWeight: FontWeight.w500,
                                                   ),
@@ -1538,20 +1714,26 @@ class GettingStarted extends StatelessWidget {
                                             children: [
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Container(
                                                 width: double.infinity,
-                                                decoration:  BoxDecoration(
-                                                  color: Theme.of(context).colorScheme.surface,
+                                                decoration: BoxDecoration(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .surface,
                                                 ),
                                               ),
                                               Padding(
@@ -1560,7 +1742,7 @@ class GettingStarted extends StatelessWidget {
                                                         .fromSTEB(12, 8, 12, 8),
                                                 child: SizedBox(
                                                   width: double.infinity,
-                                                  child:  Padding(
+                                                  child: Padding(
                                                     padding:
                                                         EdgeInsetsDirectional
                                                             .fromSTEB(
@@ -1579,7 +1761,8 @@ class GettingStarted extends StatelessWidget {
                                                                         0,
                                                                         0),
                                                             child: Text(
-                                                              key: Key('key_removing_from_wishlist'),
+                                                              key: Key(
+                                                                  'key_removing_from_wishlist'),
                                                               'To remove a game '
                                                               'to your '
                                                               'wishlist, '
@@ -1611,7 +1794,10 @@ class GettingStarted extends StatelessWidget {
                                                               style: TextStyle(
                                                                 fontFamily:
                                                                     'Inter',
-                                                                color: Theme.of(context).colorScheme.secondary,
+                                                                color: Theme.of(
+                                                                        context)
+                                                                    .colorScheme
+                                                                    .secondary,
                                                                 fontSize: 14,
                                                                 letterSpacing:
                                                                     0,
@@ -1630,12 +1816,17 @@ class GettingStarted extends StatelessWidget {
                                               SizedBox(
                                                 width: double.infinity,
                                                 child: Padding(
-                                                  padding: EdgeInsetsDirectional.fromSTEB(12, 8, 12, 8),
-                                                  child: TutorialVideo(videoPath: 'assets/videos/GameInfo_5.mp4'),
+                                                  padding: EdgeInsetsDirectional
+                                                      .fromSTEB(12, 8, 12, 8),
+                                                  child: TutorialVideo(
+                                                      videoPath:
+                                                          'assets/videos/GameInfo_5.mp4'),
                                                 ),
                                               ),
                                               Padding(
-                                                padding: const EdgeInsetsDirectional.fromSTEB(0, 4, 0, 0),
+                                                padding:
+                                                    const EdgeInsetsDirectional
+                                                        .fromSTEB(0, 4, 0, 0),
                                                 child: Container(
                                                   width: double.infinity,
                                                   decoration: BoxDecoration(),

--- a/lib/view/pages/settings/getting_started_page.dart
+++ b/lib/view/pages/settings/getting_started_page.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: prefer_const_constructors
 import 'package:flutter/material.dart';
+import 'package:gameonconnect/view/components/appbars/backbutton_appbar_component.dart';
 import 'package:gameonconnect/view/components/help/video_widget.dart';
 
 class GettingStarted extends StatelessWidget {
@@ -9,26 +10,13 @@ class GettingStarted extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       child: Scaffold(
-        appBar: AppBar(
-          automaticallyImplyLeading: false,
-          leading: IconButton(
-            icon: Icon(
-                key: Key('back_button'),
-                Icons.arrow_back,
-                color: Theme.of(context).colorScheme.secondary),
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
-          title: Text(
-            key: Key('getting_started'),
-            'Getting Started',
-            style: TextStyle(
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-              color: Theme.of(context).colorScheme.onSurface,
-            ),
-          ),
+        appBar: BackButtonAppBar(
+          title: 'Getting Started',
+          onBackButtonPressed: () {
+            Navigator.pop(context);
+          },
+          iconkey: Key('Back_button_key'),
+          textkey: Key('Getting_started_text'),
         ),
         body: SafeArea(
             top: true,

--- a/lib/view/pages/settings/help_page.dart
+++ b/lib/view/pages/settings/help_page.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: prefer_const_constructors
 import 'package:flutter/material.dart';
+import 'package:gameonconnect/view/components/appbars/backbutton_appbar_component.dart';
 
 class Help extends StatelessWidget {
   const Help({super.key});
@@ -7,23 +8,13 @@ class Help extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        appBar: AppBar(
-          title: Text(
-            'Help',
-            style: TextStyle(
-            fontSize: 32,
-            fontWeight: FontWeight.bold,
-            color: Theme.of(context).colorScheme.onSurface,
-          ),
-          ),
-          leading: IconButton(
-            key: Key('Back_button_key'),
-            icon: const Icon(Icons.keyboard_backspace),
-            color: Theme.of(context).colorScheme.secondary,
-            onPressed: () {
-              Navigator.pop(context);
-            },
-          ),
+        appBar: BackButtonAppBar(
+          title: 'Help',
+          onBackButtonPressed: () {
+            Navigator.pop(context);
+          },
+          iconkey: Key('Back_button_key'),
+          textkey: Key('Help_text'),
         ),
         body: Center(
             child:

--- a/lib/view/pages/settings/help_page.dart
+++ b/lib/view/pages/settings/help_page.dart
@@ -8,6 +8,14 @@ class Help extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
+          title: Text(
+            'Help',
+            style: TextStyle(
+            fontSize: 32,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
+          ),
           leading: IconButton(
             key: Key('Back_button_key'),
             icon: const Icon(Icons.keyboard_backspace),

--- a/lib/view/pages/settings/settings_page.dart
+++ b/lib/view/pages/settings/settings_page.dart
@@ -1,3 +1,5 @@
+import 'package:gameonconnect/view/components/appbars/backbutton_appbar_component.dart';
+
 import '../authentication/login_page.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
@@ -8,24 +10,13 @@ class Options extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-          leading: IconButton(
-          icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.secondary),
-          onPressed: () {
+      appBar: BackButtonAppBar(
+          title: 'Settings',
+          onBackButtonPressed: () {
             Navigator.pop(context);
           },
-        ),
-          title: Text(
-            'Settings',
-            style: TextStyle(
-            fontSize: 32,
-            fontWeight: FontWeight.bold,
-            color: Theme.of(context).colorScheme.onSurface,
-          ),
-          ),
-          actions: const [],
-          centerTitle: false,
-          elevation: 0,
+          iconkey: const Key('Back_button_key'),
+          textkey: const Key('settings_text'),
         ),
       body: SafeArea(
         top: true,

--- a/lib/view/pages/settings/settings_page.dart
+++ b/lib/view/pages/settings/settings_page.dart
@@ -9,31 +9,24 @@ class Options extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        toolbarHeight: 80,
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        automaticallyImplyLeading: false,
-        title:  Text(
-          key: const Key('Settings'),
-          'Settings\n',
-          style: TextStyle(
-            fontFamily: 'Inter',
-            color: Theme.of(context).colorScheme.surface,
-            fontSize: 24,
-            letterSpacing: 0,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        leading: IconButton(
-          key: const Key('back_button'),
-          color: Theme.of(context).colorScheme.surface,
-          icon: const Icon(Icons.keyboard_backspace),
+          leading: IconButton(
+          icon:  Icon(Icons.arrow_back, color: Theme.of(context).colorScheme.secondary),
           onPressed: () {
-            Navigator.of(context).pop();
+            Navigator.pop(context);
           },
         ),
-        centerTitle: true,
-        elevation: 2,
-      ),
+          title: Text(
+            'Settings',
+            style: TextStyle(
+            fontSize: 32,
+            fontWeight: FontWeight.bold,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
+          ),
+          actions: const [],
+          centerTitle: false,
+          elevation: 0,
+        ),
       body: SafeArea(
         top: true,
         child: Align(

--- a/test/getting_started_page_test.dart
+++ b/test/getting_started_page_test.dart
@@ -10,10 +10,10 @@ void main() {
       await tester.pumpAndSettle();
       await tester.pump();
 
-      expect(find.byKey(const Key('back_button'),), findsOneWidget);
+      expect(find.byKey(const Key('Back_button_key'),), findsOneWidget);
       expect(find.byKey(const Key('game_library_section'),), findsOneWidget);
       expect(find.byKey(const Key('Friends_section'),), findsOneWidget);
-      expect(find.byKey(const Key('getting_started'),), findsOneWidget);
+      expect(find.byKey(const Key('Getting_started_text'),), findsOneWidget);
       expect(find.byKey(const Key('game_information_section'),), findsOneWidget); 
     });
 

--- a/test/settings_test.dart
+++ b/test/settings_test.dart
@@ -10,12 +10,12 @@ void main() {
 
     expect(
         find.byKey(
-          const Key('Settings'),
+          const Key('settings_text'),
         ),
         findsOneWidget);
     expect(
         find.byKey(
-          const Key('back_button'),
+          const Key('Back_button_key'),
         ),
         findsOneWidget);
     expect(


### PR DESCRIPTION
1. Cleaned up the messaging. The icon has been changed, messaging text has been made bolder, removed green border around profile images, various UI fixes. The icon now only show when typing in the textbox on the chat. You can now press enter/checkmark on keyboard to also send message.  
2. Created a custom backbutton appbar for all the appbars that have backbuttons and changed those appbars to look uniform. 

I can create another custom appbar for the Feed and the profile page which takes actions? ie they both have an icon: Feed has messaging and Profile has settings. Should i do that? 😄 