### PR TITLE
Feat/leaderboardpage into Develop

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:gameonconnect/view/pages/leaderboard/view_leaderboard.dart';
 import 'package:gameonconnect/view/pages/messaging/messaging_page.dart';
 import 'package:gameonconnect/view/pages/settings/customize_page.dart';
 import 'package:gameonconnect/view/pages/game_library/game_library_page.dart';
@@ -114,6 +115,7 @@ class MyApp extends StatelessWidget {
         '/stats_leaderboard' : (context) => StatsLeaderboardPage(),
         '/stats_mood' : (context) => StatsMoodPage(),
         '/stats_genres' : (context) => GenresStatsPage(),
+        '/leaderboard' : (context) => ViewLeaderboard(),
       },
       initialRoute: '/',
     );

--- a/lib/view/components/leaderboard/leaderboard_heading_component.dart
+++ b/lib/view/components/leaderboard/leaderboard_heading_component.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+
+class LeaderboardHeading extends StatelessWidget {
+  const LeaderboardHeading({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(25, 0, 0, 0),
+          child: Row(
+            children: [
+              const Text(
+                style: TextStyle(
+                  fontFamily: "Inter",
+                ),
+                "Name",
+              ),
+              Icon(
+                Icons.arrow_drop_down,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ],
+          ),
+        ),
+        Row(
+          children: [
+            const Text(
+              style: TextStyle(
+                fontFamily: "Inter",
+              ),
+              "Points",
+            ),
+            Icon(
+              Icons.arrow_drop_down,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/components/leaderboard/rank_row_component.dart
+++ b/lib/view/components/leaderboard/rank_row_component.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class RankRowComponent extends StatelessWidget {
+  final String rank;
+  final String teamName;
+  final int points;
+
+  const RankRowComponent({
+    required this.rank,
+    required this.teamName,
+    required this.points,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+      ),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(5, 0, 10, 0),
+                  child: Text(
+                    rank,
+                    style: TextStyle(
+                      fontFamily: "Inter",
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFD9D9D9),
+                      borderRadius: BorderRadius.circular(40),
+                    ),
+                    child: const SizedBox(
+                      width: 40,
+                      height: 40,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
+                  child: Text(
+                    teamName,
+                    style: TextStyle(
+                      fontFamily: "Inter",
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(0, 0, 40, 0),
+                  child: Text(
+                    points.toString(),
+                    style: TextStyle(
+                      fontFamily: "Inter",
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.secondary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/components/leaderboard/tournament_name_component.dart
+++ b/lib/view/components/leaderboard/tournament_name_component.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+class TournamentNameComponent extends StatelessWidget {
+  final String tournamentName;
+  final VoidCallback onEditScoresPressed;
+
+  const TournamentNameComponent({
+    super.key,
+    required this.tournamentName,
+    required this.onEditScoresPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          tournamentName,
+          style: TextStyle(
+            fontWeight: FontWeight.w700,
+            fontSize: 25,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+        ),
+        MaterialButton(
+          height: 30,
+          minWidth: 30,
+          onPressed: onEditScoresPressed,
+          color: Theme.of(context).colorScheme.surface,
+          textColor: Theme.of(context).colorScheme.secondary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20.0), // Rounded corners
+            side: BorderSide(
+              color: Theme.of(context).colorScheme.primary, // Green edge
+            ),
+          ),
+          child: const Text(
+            'Edit Scores',
+            style: TextStyle(
+              fontSize: 12,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/components/leaderboard/winner_component.dart
+++ b/lib/view/components/leaderboard/winner_component.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+
+class WinnerComponent extends StatelessWidget {
+  final String teamName;
+  final String status;
+  final String rank;
+  final String points;
+
+  const WinnerComponent({
+    super.key,
+    required this.teamName,
+    required this.status,
+    required this.rank,
+    required this.points,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(0, 0, 15, 0),
+              child: Container(
+                margin: const EdgeInsets.fromLTRB(0, 0, 0, 5),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFD9D9D9),
+                    borderRadius: BorderRadius.circular(40),
+                  ),
+                  child: const SizedBox(
+                    width: 60,
+                    height: 60,
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        teamName,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 20,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                      ),
+                      Text(
+                        status,
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Theme.of(context).colorScheme.secondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Column(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.fromLTRB(15, 5, 15, 5),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(10.0),
+                          border: Border.all(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .secondary
+                                .withOpacity(0.2),
+                          ),
+                        ),
+                        child: Column(
+                          children: [
+                            Text(
+                              rank,
+                              style: TextStyle(
+                                fontWeight: FontWeight.w700,
+                                fontFamily: "Inter",
+                                fontSize: 20,
+                                color: Theme.of(context).colorScheme.secondary,
+                              ),
+                            ),
+                            Text(
+                              "Rank",
+                              style: TextStyle(
+                                fontFamily: "Inter",
+                                fontSize: 12,
+                                color: Theme.of(context).colorScheme.secondary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  Column(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(10.0),
+                          border: Border.all(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .secondary
+                                .withOpacity(0.2),
+                          ),
+                        ),
+                        child: Column(
+                          children: [
+                            Text(
+                              points,
+                              style: TextStyle(
+                                fontWeight: FontWeight.w700,
+                                fontFamily: "Inter",
+                                fontSize: 20,
+                                color: Theme.of(context).colorScheme.secondary,
+                              ),
+                            ),
+                            Text(
+                              "Points",
+                              style: TextStyle(
+                                fontFamily: "Inter",
+                                fontSize: 12,
+                                color: Theme.of(context).colorScheme.secondary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(
+          height: 10,
+        ),
+        Divider(
+          color: Theme.of(context).colorScheme.secondary,
+          thickness: 0.3,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/pages/feed/feed_page.dart
+++ b/lib/view/pages/feed/feed_page.dart
@@ -10,6 +10,7 @@ import 'package:gameonconnect/view/components/feed/event_invite_list.dart';
 import 'package:gameonconnect/view/components/feed/online_friends_list.dart';
 import 'package:gameonconnect/view/components/feed/start_timer.dart';
 import 'package:gameonconnect/view/pages/game_library/game_library_page.dart';
+import 'package:gameonconnect/view/pages/leaderboard/view_leaderboard.dart';
 import 'package:gameonconnect/view/pages/messaging/messaging_page.dart';
 import 'package:gameonconnect/view/pages/profile/profile_page.dart';
 import 'package:gameonconnect/view/pages/events/create_events_page.dart';
@@ -343,6 +344,23 @@ class _FeedPageDisplay extends StatelessWidget {
           ),
         ),
         actions: <Widget>[
+          Padding(
+            padding: const EdgeInsets.only(right: 10.0),
+            child: IconButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const ViewLeaderboard(),
+                  ),
+                );
+              },
+              icon: Icon(
+                Icons.leaderboard,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+            ),
+          ),
           Padding(
             padding: const EdgeInsets.only(right: 20.0),
             child: IconButton(

--- a/lib/view/pages/leaderboard/view_leaderboard.dart
+++ b/lib/view/pages/leaderboard/view_leaderboard.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+class ViewLeaderboard extends StatefulWidget {
+  const ViewLeaderboard({super.key});
+
+  @override
+  State<ViewLeaderboard> createState() => _ViewLeaderboardState();
+}
+
+//NB rename
+class _ViewLeaderboardState extends State<ViewLeaderboard> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Leaderboard",
+            style: TextStyle(fontSize: 32, fontWeight: FontWeight.bold)),
+        actions: <Widget>[
+          Padding(
+            padding: const EdgeInsets.only(right: 20.0),
+            child: IconButton(
+              onPressed: () {
+                /*Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => const ViewLeaderboard(),
+                  ),
+                ); */
+              },
+              icon: Icon(
+                Icons.settings,
+                color: Theme.of(context).colorScheme.primary,
+                size: 25.0,
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: SizedBox(
+        width: double.infinity,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(
+                height: 15,
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Poker Tournament',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 25,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                  MaterialButton(
+                    height: 30,
+                    onPressed: () {
+                      //Navigator.push(context, MaterialPageRoute(builder: (context) => const ViewLeaderboard()));
+                    },
+                    color: Theme.of(context).colorScheme.surface,
+                    textColor: Theme.of(context).colorScheme.secondary,
+                    shape: RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.circular(20.0), // Rounded corners
+                      side: BorderSide(
+                        color:
+                            Theme.of(context).colorScheme.primary, // Green edge
+                      ),
+                    ),
+                    child: const Text(
+                      'Edit Scores',
+                      style: TextStyle(
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(
+                height: 25,
+              ),
+              Container(
+                margin: const EdgeInsets.fromLTRB(0, 0, 0, 5),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFD9D9D9),
+                    borderRadius: BorderRadius.circular(40),
+                  ),
+                  child: const SizedBox(
+                    width: 60,
+                    height: 60,
+                  ),
+                ),
+              ),
+              const SizedBox(
+                height: 10,
+              ),
+              SingleChildScrollView(
+                scrollDirection: Axis.vertical,
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFD9D9D9),
+                    borderRadius: BorderRadius.circular(15),
+                  ),
+                  child: Container(
+                    padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
+                    child: const Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        //here the components will go for each user in the rankings
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/pages/leaderboard/view_leaderboard.dart
+++ b/lib/view/pages/leaderboard/view_leaderboard.dart
@@ -1,4 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:gameonconnect/view/components/leaderboard/rank_row_component.dart';
+import 'package:gameonconnect/view/components/leaderboard/leaderboard_heading_component.dart';
+import 'package:gameonconnect/view/components/leaderboard/tournament_name_component.dart';
+import 'package:gameonconnect/view/components/leaderboard/winner_component.dart';
 
 class ViewLeaderboard extends StatefulWidget {
   const ViewLeaderboard({super.key});
@@ -46,289 +50,53 @@ class _ViewLeaderboardState extends State<ViewLeaderboard> {
                 const SizedBox(
                   height: 15,
                 ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      'Poker Tournament',
-                      style: TextStyle(
-                        fontWeight: FontWeight.w700,
-                        fontSize: 25,
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
-                    MaterialButton(
-                      height: 30,
-                      minWidth: 30,
-                      onPressed: () {
-                        //Navigator.push(context, MaterialPageRoute(builder: (context) => const ViewLeaderboard()));
-                      },
-                      color: Theme.of(context).colorScheme.surface,
-                      textColor: Theme.of(context).colorScheme.secondary,
-                      shape: RoundedRectangleBorder(
-                        borderRadius:
-                            BorderRadius.circular(20.0), // Rounded corners
-                        side: BorderSide(
-                          color: Theme.of(context)
-                              .colorScheme
-                              .primary, // Green edge
-                        ),
-                      ),
-                      child: const Text(
-                        'Edit Scores',
-                        style: TextStyle(
-                          fontSize: 12,
-                        ),
-                      ),
-                    ),
-                  ],
+                TournamentNameComponent(
+                  tournamentName: 'Poker Tournament',
+                  onEditScoresPressed: () {
+                    //Navigator.push(context, MaterialPageRoute(builder: (context) => const ViewLeaderboard()));
+                  },
                 ),
                 const SizedBox(
                   height: 25,
                 ),
-                Row(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 0, 15, 0),
-                      child: Container(
-                        margin: const EdgeInsets.fromLTRB(0, 0, 0, 5),
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: const Color(0xFFD9D9D9),
-                            borderRadius: BorderRadius.circular(40),
-                          ),
-                          child: const SizedBox(
-                            width: 60,
-                            height: 60,
-                          ),
-                        ),
-                      ),
-                    ),
-                    Expanded(
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                "Team 1",
-                                style: TextStyle(
-                                  fontWeight: FontWeight.w700,
-                                  fontSize: 20,
-                                  color:
-                                      Theme.of(context).colorScheme.secondary,
-                                ),
-                              ),
-                              Text(
-                                "Winning",
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color:
-                                      Theme.of(context).colorScheme.secondary,
-                                ),
-                              ),
-                            ],
-                          ),
-                          Column(
-                            children: [
-                              Container(
-                                padding: const EdgeInsets.fromLTRB(15, 5, 15, 5),
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).colorScheme.surface,
-                                  borderRadius: BorderRadius.circular(10.0),
-                                  border: Border.all(
-                                    color:
-                                        Theme.of(context).colorScheme.secondary,
-                                  ),
-                                ),
-                                child: Column(
-                                  children: [
-                                    Text(
-                                      "1st",
-                                      style: TextStyle(
-                                        fontWeight: FontWeight.w700,
-                                        fontFamily: "Inter",
-                                        fontSize: 20,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary,
-                                      ),
-                                    ),
-                                    Text(
-                                      "Rank",
-                                      style: TextStyle(
-                                        fontFamily: "Inter",
-                                        fontSize: 12,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                          Column(
-                            children: [
-                              Container(
-                                padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context).colorScheme.surface,
-                                  borderRadius: BorderRadius.circular(10.0),
-                                  border: Border.all(
-                                    color:
-                                        Theme.of(context).colorScheme.secondary,
-                                  ),
-                                ),
-                                child: Column(
-                                  children: [
-                                    Text(
-                                      "20",
-                                      style: TextStyle(
-                                        fontWeight: FontWeight.w700,
-                                        fontFamily: "Inter",
-                                        fontSize: 20,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary,
-                                      ),
-                                    ),
-                                    Text(
-                                      "Points",
-                                      style: TextStyle(
-                                        fontFamily: "Inter",
-                                        fontSize: 12,
-                                        color: Theme.of(context)
-                                            .colorScheme
-                                            .secondary,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
+                const WinnerComponent(
+                  teamName: "Team 1",
+                  status: "Winning",
+                  rank: "1st",
+                  points: "20",
                 ),
                 const SizedBox(
                   height: 10,
                 ),
-                Divider(
-                  color: Theme.of(context).colorScheme.secondary,
-                  thickness: 0.3,
-                ),
-                const SizedBox(
-                  height: 10,
-                ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 0, 0, 0),
-                      child: Row(
-                        children: [
-                          const Text(
-                            style: TextStyle(
-                              fontFamily: "Inter",
-                            ),
-                            "Name",
-                          ),
-                          Icon(
-                            Icons.arrow_drop_down,
-                            color: Theme.of(context).colorScheme.primary,
-                          ),
-                        ],
-                      ),
-                    ),
-                    Row(
-                      children: [
-                        const Text(
-                          style: TextStyle(
-                              fontFamily: "Inter",
-                            ),
-                          "Points",
-                        ),
-                        Icon(
-                          Icons.arrow_drop_down,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
+                const LeaderboardHeading(),
               ],
             ),
           ),
-          SingleChildScrollView(
+          const SingleChildScrollView(
             scrollDirection: Axis.vertical,
-            child: Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-              ),
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(0, 0, 5, 0),
-                          child: Text(
-                            "2nd",
-                            style: TextStyle(
-                              fontFamily: "Inter",
-                              fontSize: 12,
-                              color: Theme.of(context).colorScheme.secondary,
-                            ),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: const Color(0xFFD9D9D9),
-                              borderRadius: BorderRadius.circular(40),
-                            ),
-                            child: const SizedBox(
-                              width: 40,
-                              height: 40,
-                            ),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
-                          child: Text(
-                            "Team 2",
-                            style: TextStyle(
-                              fontFamily: "Inter",
-                              fontSize: 12,
-                              color: Theme.of(context).colorScheme.secondary,
-                            ),
-                          ),
-                        ),
-                        const Spacer(),
-                        Padding(
-                          padding: const EdgeInsets.fromLTRB(0, 0, 40, 0),
-                          child: Text(
-                            "17",
-                            style: TextStyle(
-                              fontFamily: "Inter",
-                              fontSize: 12,
-                              color: Theme.of(context).colorScheme.secondary,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
+            child: Column(
+              children: [
+                RankRowComponent(
+                  rank: "2nd",
+                  teamName: "Team 2",
+                  points: 0,
                 ),
-              ),
+                RankRowComponent(
+                  rank: "3rd",
+                  teamName: "Team 3",
+                  points: 0,
+                ),
+                RankRowComponent(
+                  rank: "4th",
+                  teamName: "Team 4",
+                  points: 0,
+                ),
+                RankRowComponent(
+                  rank: "5th",
+                  teamName: "Team 5",
+                  points: 0,
+                ),
+              ],
             ),
           )
         ],

--- a/lib/view/pages/leaderboard/view_leaderboard.dart
+++ b/lib/view/pages/leaderboard/view_leaderboard.dart
@@ -7,7 +7,6 @@ class ViewLeaderboard extends StatefulWidget {
   State<ViewLeaderboard> createState() => _ViewLeaderboardState();
 }
 
-//NB rename
 class _ViewLeaderboardState extends State<ViewLeaderboard> {
   @override
   Widget build(BuildContext context) {
@@ -36,93 +35,303 @@ class _ViewLeaderboardState extends State<ViewLeaderboard> {
           ),
         ],
       ),
-      body: SizedBox(
-        width: double.infinity,
-        child: Padding(
-          padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(
-                height: 15,
-              ),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    'Poker Tournament',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w700,
-                      fontSize: 25,
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-                  ),
-                  MaterialButton(
-                    height: 30,
-                    onPressed: () {
-                      //Navigator.push(context, MaterialPageRoute(builder: (context) => const ViewLeaderboard()));
-                    },
-                    color: Theme.of(context).colorScheme.surface,
-                    textColor: Theme.of(context).colorScheme.secondary,
-                    shape: RoundedRectangleBorder(
-                      borderRadius:
-                          BorderRadius.circular(20.0), // Rounded corners
-                      side: BorderSide(
-                        color:
-                            Theme.of(context).colorScheme.primary, // Green edge
-                      ),
-                    ),
-                    child: const Text(
-                      'Edit Scores',
-                      style: TextStyle(
-                        fontSize: 12,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(
-                height: 25,
-              ),
-              Container(
-                margin: const EdgeInsets.fromLTRB(0, 0, 0, 5),
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFD9D9D9),
-                    borderRadius: BorderRadius.circular(40),
-                  ),
-                  child: const SizedBox(
-                    width: 60,
-                    height: 60,
-                  ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(
+                  height: 15,
                 ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              SingleChildScrollView(
-                scrollDirection: Axis.vertical,
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: const Color(0xFFD9D9D9),
-                    borderRadius: BorderRadius.circular(15),
-                  ),
-                  child: Container(
-                    padding: const EdgeInsets.fromLTRB(0, 0, 0, 0),
-                    child: const Column(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      crossAxisAlignment: CrossAxisAlignment.start,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'Poker Tournament',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w700,
+                        fontSize: 25,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    ),
+                    MaterialButton(
+                      height: 30,
+                      minWidth: 30,
+                      onPressed: () {
+                        //Navigator.push(context, MaterialPageRoute(builder: (context) => const ViewLeaderboard()));
+                      },
+                      color: Theme.of(context).colorScheme.surface,
+                      textColor: Theme.of(context).colorScheme.secondary,
+                      shape: RoundedRectangleBorder(
+                        borderRadius:
+                            BorderRadius.circular(20.0), // Rounded corners
+                        side: BorderSide(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .primary, // Green edge
+                        ),
+                      ),
+                      child: const Text(
+                        'Edit Scores',
+                        style: TextStyle(
+                          fontSize: 12,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 25,
+                ),
+                Row(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 0, 15, 0),
+                      child: Container(
+                        margin: const EdgeInsets.fromLTRB(0, 0, 0, 5),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFD9D9D9),
+                            borderRadius: BorderRadius.circular(40),
+                          ),
+                          child: const SizedBox(
+                            width: 60,
+                            height: 60,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                "Team 1",
+                                style: TextStyle(
+                                  fontWeight: FontWeight.w700,
+                                  fontSize: 20,
+                                  color:
+                                      Theme.of(context).colorScheme.secondary,
+                                ),
+                              ),
+                              Text(
+                                "Winning",
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  color:
+                                      Theme.of(context).colorScheme.secondary,
+                                ),
+                              ),
+                            ],
+                          ),
+                          Column(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.fromLTRB(15, 5, 15, 5),
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.surface,
+                                  borderRadius: BorderRadius.circular(10.0),
+                                  border: Border.all(
+                                    color:
+                                        Theme.of(context).colorScheme.secondary,
+                                  ),
+                                ),
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      "1st",
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.w700,
+                                        fontFamily: "Inter",
+                                        fontSize: 20,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
+                                      ),
+                                    ),
+                                    Text(
+                                      "Rank",
+                                      style: TextStyle(
+                                        fontFamily: "Inter",
+                                        fontSize: 12,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                          Column(
+                            children: [
+                              Container(
+                                padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context).colorScheme.surface,
+                                  borderRadius: BorderRadius.circular(10.0),
+                                  border: Border.all(
+                                    color:
+                                        Theme.of(context).colorScheme.secondary,
+                                  ),
+                                ),
+                                child: Column(
+                                  children: [
+                                    Text(
+                                      "20",
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.w700,
+                                        fontFamily: "Inter",
+                                        fontSize: 20,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
+                                      ),
+                                    ),
+                                    Text(
+                                      "Points",
+                                      style: TextStyle(
+                                        fontFamily: "Inter",
+                                        fontSize: 12,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .secondary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                Divider(
+                  color: Theme.of(context).colorScheme.secondary,
+                  thickness: 0.3,
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 0, 0, 0),
+                      child: Row(
+                        children: [
+                          const Text(
+                            style: TextStyle(
+                              fontFamily: "Inter",
+                            ),
+                            "Name",
+                          ),
+                          Icon(
+                            Icons.arrow_drop_down,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Row(
                       children: [
-                        //here the components will go for each user in the rankings
+                        const Text(
+                          style: TextStyle(
+                              fontFamily: "Inter",
+                            ),
+                          "Points",
+                        ),
+                        Icon(
+                          Icons.arrow_drop_down,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
                       ],
                     ),
-                  ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          SingleChildScrollView(
+            scrollDirection: Axis.vertical,
+            child: Container(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+              ),
+              child: Container(
+                padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(0, 0, 5, 0),
+                          child: Text(
+                            "2nd",
+                            style: TextStyle(
+                              fontFamily: "Inter",
+                              fontSize: 12,
+                              color: Theme.of(context).colorScheme.secondary,
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: const Color(0xFFD9D9D9),
+                              borderRadius: BorderRadius.circular(40),
+                            ),
+                            child: const SizedBox(
+                              width: 40,
+                              height: 40,
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
+                          child: Text(
+                            "Team 2",
+                            style: TextStyle(
+                              fontFamily: "Inter",
+                              fontSize: 12,
+                              color: Theme.of(context).colorScheme.secondary,
+                            ),
+                          ),
+                        ),
+                        const Spacer(),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(0, 0, 40, 0),
+                          child: Text(
+                            "17",
+                            style: TextStyle(
+                              fontFamily: "Inter",
+                              fontSize: 12,
+                              color: Theme.of(context).colorScheme.secondary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
               ),
-            ],
-          ),
-        ),
+            ),
+          )
+        ],
       ),
     );
   }


### PR DESCRIPTION
Implemented the leaderboard view:
Note this is purely the frontend.

1. You can find the leaderboard page on the Feed Page, I put it there for now, since we don't have a leaderboard button on events, this can be moved later.
2. You find that the design closely matches Franco's design on Figma. The colors for the boxes and the text is not white (see DarkMode), I assume this will be rectified when we fix the themes. 
3. You'll see that the first RankRowComponent does not align with the rest of the RankRowComponents, your advice to get this aligned is appreciated. Did not want to spend too much time here, because the intention is for the RankRowComponents to be built by a FutureBuilder/StreamBuilder, which will hopefully fix the alignment issue. 
4. You'll find I split up the code into components to make the code more modular and digestible. I also tried to make them with the backend in mind, so data can be passed over more easily via components. 

Please let me know what you think. Also please see the leaderboard in light and dark mode. 