### PR TITLE
fixed overflow

### DIFF
--- a/lib/view/pages/events/view_events_page.dart
+++ b/lib/view/pages/events/view_events_page.dart
@@ -164,7 +164,7 @@ class _HomePageWidgetState extends State<ViewEvents> {
                                                           const Alignment(
                                                               0, 1),
                                                       child: ButtonsTabBar(
-                                                        width: 100,
+                                                        width: 101,
                                                         contentCenter: true,
                                                         labelStyle: TextStyle(
                                                           fontFamily: 'Inter',
@@ -188,7 +188,7 @@ class _HomePageWidgetState extends State<ViewEvents> {
                                                                 .colorScheme
                                                                 .primaryContainer,
                                                         elevation: 0,
-                                                        buttonMargin: const EdgeInsets.fromLTRB(0, 0, 14, 10),
+                                                        buttonMargin: const EdgeInsets.fromLTRB(0, 0, 13, 10),
                                                         backgroundColor:
                                                             Theme.of(context)
                                                                 .colorScheme


### PR DESCRIPTION
There was an overflow on the view events page when clicking on the subscribe button. This has been fixed by making the length of the button 1 more