### PR TITLE
edit event update how data is edited

### DIFF
--- a/lib/services/events_S/event_service.dart
+++ b/lib/services/events_S/event_service.dart
@@ -348,7 +348,7 @@ class EventsService {
           await imageStorage.putFile(File(url));
         }
 
-        db.collection("events").doc(eventId).set(data);
+        db.collection("events").doc(eventId).set(data, SetOptions(merge: true));
       }
     }
   }


### PR DESCRIPTION
Edit event should no longer over write the old data in the database, this caused the creator name to be removed when editing event