### PR TITLE
Badges frontend merge

### DIFF
--- a/lib/services/badges_S/badge_service.dart
+++ b/lib/services/badges_S/badge_service.dart
@@ -1,6 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:gameonconnect/services/connection_S/connection_service.dart';
+import 'package:gameonconnect/services/profile_S/storage_service.dart';
 import 'package:gameonconnect/services/stats_S/stats_total_time_service.dart';
 
 class BadgeService {
@@ -14,6 +16,37 @@ class BadgeService {
 
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  Future<List<String>> getConnectionsBadgeStatus(String badgeName) async {
+  final currentUser = _auth.currentUser?.uid;
+
+  List<String> connections = await ConnectionService().getConnections("connections", currentUser);
+  List<String> unlockedProfiles = []; 
+
+  for (String connectionId in connections) {
+    try {
+      DocumentSnapshot<Map<String, dynamic>> badgeSnapshot =
+          await _firestore.collection('badges').doc(connectionId).get();
+
+      if (badgeSnapshot.exists && badgeSnapshot.data() != null) {
+        Map<String, dynamic> badgeData = badgeSnapshot.data()!;
+
+        if (badgeData.containsKey(badgeName) && badgeData[badgeName]['unlocked'] == true) {
+          StorageService storageService = StorageService();
+          String profilePictureUrl =
+              await storageService.getProfilePictureUrl(currentUser!);
+
+          unlockedProfiles.add(profilePictureUrl);
+        }
+      }
+    } catch (e) {
+      //print("Error checking badge for user $connectionId: $e");
+    }
+  }
+
+  return unlockedProfiles;
+}
+
 
   Future<Map<String, dynamic>> getBadges() async {
     final currentUser = _auth.currentUser;

--- a/lib/services/badges_S/badge_service.dart
+++ b/lib/services/badges_S/badge_service.dart
@@ -34,7 +34,7 @@ class BadgeService {
         if (badgeData.containsKey(badgeName) && badgeData[badgeName]['unlocked'] == true) {
           StorageService storageService = StorageService();
           String profilePictureUrl =
-              await storageService.getProfilePictureUrl(currentUser!);
+              await storageService.getProfilePictureUrl(connectionId);
 
           unlockedProfiles.add(profilePictureUrl);
         }

--- a/lib/view/pages/badges/achievement_badges.dart
+++ b/lib/view/pages/badges/achievement_badges.dart
@@ -1,40 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:gameonconnect/view/pages/badges/badge_page.dart';
-import 'package:gameonconnect/services/badges_S/badge_service.dart';
 import 'package:intl/intl.dart';
-import 'package:loading_animation_widget/loading_animation_widget.dart';
 
 class AchievementBadgesPage extends StatefulWidget {
-  const AchievementBadgesPage({super.key});
+  final Map<String, dynamic> badges;
+
+  const AchievementBadgesPage({super.key, required this.badges});
 
   @override
   State<AchievementBadgesPage> createState() => _AchievementBadgesPageState();
 }
 
 class _AchievementBadgesPageState extends State<AchievementBadgesPage> {
-  Map<String, dynamic> badges = {};
-  bool isLoading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    fetchBadges();
-  }
-
-  Future<void> fetchBadges() async {
-    try {
-      Map<String, dynamic> badgeData = await BadgeService().getBadges();
-      setState(() {
-        badges = badgeData;
-        isLoading = false;
-      });
-    } catch (e) {
-      SnackBar(content: Text(e.toString()));
-      setState(() {
-        isLoading = false;
-      });
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -47,135 +24,133 @@ class _AchievementBadgesPageState extends State<AchievementBadgesPage> {
                 fontSize: 16,
                 color: Theme.of(context).colorScheme.primary)),
       ),
-      body: isLoading
-          ? Center(
-              child: LoadingAnimationWidget.halfTriangleDot(
-                color: Theme.of(context).colorScheme.primary,
-                size: 36,
-              ),
-            )
-          : badges.isEmpty
-              ? const Center(child: Text("No badges found"))
-              : Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: GridView.builder(
-                    gridDelegate:
-                        const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      crossAxisSpacing: 20,
-                      mainAxisSpacing: 20,
-                    ),
-                    itemCount: badges.length,
-                    itemBuilder: (context, index) {
-                      final badgeEntry = badges.entries.elementAt(index);
-                      final badgeName = badgeEntry.key; 
-                      final badgeDetails = badgeEntry.value; 
-
-                      return GestureDetector(
-                        onTap: badgeDetails['unlocked']
-                            ? () {
-                                Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                      builder: (context) =>
-                                          BadgePage(badge: badgeEntry)),
-                                );
-                              }
-                            : null,
-                        child: Stack(
-                          children: [
-                            Container(
-                              padding: const EdgeInsets.all(15),
-                              decoration: BoxDecoration(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .primaryContainer,
-                                borderRadius: BorderRadius.circular(15),
-                              ),
-                              child: Center(
-                                child: Column(
-                                  children: [
-                                    Expanded(
-                                      child: badgeDetails['unlocked']
-                                          ? Image.asset(
-                                              'assets/badges_images/$badgeName.png',
-                                              height: 85,
-                                              width: 85,
-                                              fit: BoxFit.contain)
-                                          : ColorFiltered(
-                                              colorFilter: const ColorFilter
-                                                  .matrix(<double>[
-                                                0.2126,
-                                                0.7152,
-                                                0.0722,
-                                                0,
-                                                0,
-                                                0.2126,
-                                                0.7152,
-                                                0.0722,
-                                                0,
-                                                0,
-                                                0.2126,
-                                                0.7152,
-                                                0.0722,
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                0,
-                                                1,
-                                                0,
-                                              ]),
-                                              child: Image.asset(
-                                                'assets/badges_images/$badgeName.png',
-                                                height: 85,
-                                                width: 85,
-                                                fit: BoxFit.contain,
-                                              ),
-                                            ),
-                                    ),
-                                    Padding(
-                                      padding: const EdgeInsets.only(top: 9),
-                                      child: Text(
-                                        textAlign: TextAlign.center,
-                                        badgeName.replaceAll('_', ' ').toUpperCase(),
-                                        style: const TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 12,
-                                            fontWeight: FontWeight.bold),
-                                      ),
-                                    ),
-                                    badgeDetails['unlocked']
-                                        ? Padding(
-                                            padding: const EdgeInsets.all(9),
-                                            child: Text(
-                                              DateFormat('yyyy/MM/dd').format(badgeDetails['date_unlocked'].toDate()),
-                                              style: const TextStyle(
-                                                  color: Colors.grey,
-                                                  fontSize: 12),
-                                            ),
-                                          )
-                                        : const SizedBox(),
-                                  ],
-                                ),
-                              ),
-                            ),
-                            if (!badgeDetails['unlocked'])
-                              Positioned(
-                                top: 15,
-                                right: 15,
-                                child: Icon(
-                                  Icons.lock,
-                                  color: Colors.white.withOpacity(0.8),
-                                  size: 24,
-                                ),
-                              ),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
+      body: widget.badges.isEmpty
+          ? const Center(child: Text("No badges found"))
+          : Padding(
+              padding: const EdgeInsets.all(12),
+              child: GridView.builder(
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 2,
+                  crossAxisSpacing: 20,
+                  mainAxisSpacing: 20,
                 ),
+                itemCount: widget.badges.length,
+                itemBuilder: (context, index) {
+                  final badgeEntry = widget.badges.entries.elementAt(index);
+                  final badgeName = badgeEntry.key;
+                  final badgeDetails = badgeEntry.value;
+
+                  return GestureDetector(
+                    onTap: badgeDetails['unlocked'] &&
+                            badgeDetails['date_unlocked'] != null
+                        ? () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                  builder: (context) =>
+                                      BadgePage(badge: badgeEntry)),
+                            );
+                          }
+                        : null,
+                    child: Stack(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.all(15),
+                          decoration: BoxDecoration(
+                            color:
+                                Theme.of(context).colorScheme.primaryContainer,
+                            borderRadius: BorderRadius.circular(15),
+                          ),
+                          child: Center(
+                            child: Column(
+                              children: [
+                                Expanded(
+                                  child: badgeDetails['unlocked'] &&
+                                          badgeDetails['date_unlocked'] != null
+                                      ? Image.asset(
+                                          'assets/badges_images/$badgeName.png',
+                                          height: 85,
+                                          width: 85,
+                                          fit: BoxFit.contain)
+                                      : ColorFiltered(
+                                          colorFilter:
+                                              const ColorFilter.matrix(<double>[
+                                            0.2126,
+                                            0.7152,
+                                            0.0722,
+                                            0,
+                                            0,
+                                            0.2126,
+                                            0.7152,
+                                            0.0722,
+                                            0,
+                                            0,
+                                            0.2126,
+                                            0.7152,
+                                            0.0722,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            0,
+                                            1,
+                                            0,
+                                          ]),
+                                          child: Image.asset(
+                                            'assets/badges_images/$badgeName.png',
+                                            height: 85,
+                                            width: 85,
+                                            fit: BoxFit.contain,
+                                          ),
+                                        ),
+                                ),
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 9),
+                                  child: Text(
+                                    textAlign: TextAlign.center,
+                                    badgeName
+                                        .replaceAll('_', ' ')
+                                        .toUpperCase(),
+                                    style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.bold),
+                                  ),
+                                ),
+                                badgeDetails['unlocked'] &&
+                                        badgeDetails['date_unlocked'] != null
+                                    ? Padding(
+                                        padding: const EdgeInsets.all(9),
+                                        child: Text(
+                                          DateFormat('yyyy/MM/dd').format(
+                                              badgeDetails['date_unlocked']
+                                                  .toDate()),
+                                          style: const TextStyle(
+                                              color: Colors.grey, fontSize: 12),
+                                        ),
+                                      )
+                                    : const SizedBox(),
+                              ],
+                            ),
+                          ),
+                        ),
+                        if (!badgeDetails['unlocked'] ||
+                            badgeDetails['date_unlocked'] == null)
+                          Positioned(
+                            top: 15,
+                            right: 15,
+                            child: Icon(
+                              Icons.lock,
+                              color: Colors.white.withOpacity(0.8),
+                              size: 24,
+                            ),
+                          ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
     );
   }
 }

--- a/lib/view/pages/home/home_page.dart
+++ b/lib/view/pages/home/home_page.dart
@@ -39,7 +39,6 @@ class _HomePageState extends State<HomePage> {
 
   late String currentUserId; // Declare currentUserId here
   late List<Widget> _pages; // Declare _pages as late
- 
 
   @override
   void initState() {
@@ -301,7 +300,7 @@ class _HomePageDisplayState extends State<_HomePageDisplay> {
   initState() {
     super.initState();
     currentUserId = FirebaseAuth.instance.currentUser!.uid;
-    fetchUsername(); 
+    fetchUsername();
   }
 
   Future<void> fetchUsername() async {
@@ -381,9 +380,7 @@ class _HomePageDisplayState extends State<_HomePageDisplay> {
           ),
           actions: <Widget>[
             Padding(
-              padding: EdgeInsets.only(
-                  right:20.0,
-                  top: 16.0),
+              padding: const EdgeInsets.only(right: 20.0, top: 16.0),
               child: IconButton(
                 onPressed: () {
                   Navigator.push(

--- a/lib/view/pages/profile/profile_page.dart
+++ b/lib/view/pages/profile/profile_page.dart
@@ -16,6 +16,7 @@ import 'package:gameonconnect/view/components/profile/bio.dart';
 import 'package:gameonconnect/view/components/profile/profile_buttons.dart';
 import 'package:gameonconnect/view/components/profile/action_button.dart';
 import 'package:gameonconnect/view/components/profile/request_container.dart';
+import 'package:gameonconnect/view/pages/badges/achievement_badges.dart';
 import 'package:gameonconnect/view/pages/messaging/chat_page.dart';
 import 'package:gameonconnect/view/pages/profile/connections_list.dart';
 import 'package:gameonconnect/view/pages/profile/my_gameslist.dart';
@@ -55,6 +56,8 @@ class _ProfileState extends State<ProfilePage> {
   bool isPendingOfParent = false;
   bool isConnectionOfParent = false;
   bool isRequestToParent = false;
+  Map<String, dynamic> _badges = {};
+  int _badgesCount = 0;
 
   Future<void> isConnectionOfLoggedInUser() async {
     final connections = await ConnectionService().getConnections('connections');
@@ -203,6 +206,19 @@ class _ProfileState extends State<ProfilePage> {
     );
   }
 
+  Future<void> getNumBadges() async {
+    _badges = await BadgeService().getBadges();
+    int count = 0;
+
+    for (Map<String, dynamic> badge in _badges.values) {
+      if (badge['unlocked']) {
+        count++;
+      }
+    }
+
+    _badgesCount = count;
+  }
+
   void navigateToStats(BuildContext context) {
     Navigator.push(
       context,
@@ -218,6 +234,7 @@ class _ProfileState extends State<ProfilePage> {
     super.initState();
     getRelationToLoggedInUser();
     getTimePlayed();
+    getNumBadges();
     _badgeService.unlockNightOwlBadge(DateTime.now());
   }
 
@@ -433,8 +450,14 @@ class _ProfileState extends State<ProfilePage> {
                                   Expanded(
                                     child: ProfileButton(
                                         value:
-                                            '${_profileService.mygGamesLength}',
-                                        title: 'Games'),
+                                            _badgesCount.toString(),
+                                        title: 'Badges',
+                                        onPressed:() {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(builder: (context) => AchievementBadgesPage(badges: _badges)),
+                                          );
+                                        },),
                                   ),
                                   Expanded(
                                     child: ProfileButton(


### PR DESCRIPTION
These should be the final changes to integrating the badges with the backend.  I did the following:

1. I added the badge descriptions to the specific badge page
2. I added the profile images of connections who also unlocked the badge to the avatar stack in the badge page
3. I fixed the issue where a badge is loaded when "date_unlocked" is null.
4. I changed the navigation to the badge page to be on the profile page
5. I added the number of unlocked badges to the profile page (where you can navigate to the badge page)
